### PR TITLE
fix: Resolve LiftError status codes not being properly mapped to HTTP responses

### DIFF
--- a/LIFT_RESPONSE_CODES.md
+++ b/LIFT_RESPONSE_CODES.md
@@ -1,0 +1,241 @@
+# Lift Framework Issue: LiftError Status Codes Not Properly Set in HTTP Responses
+
+## ✅ RESOLVED
+
+This issue has been **FIXED** in the latest version. The `handleError` method in `pkg/lift/app.go` now properly handles `LiftError` objects and maps their status codes to HTTP responses.
+
+## Summary
+
+After successfully upgrading to lift v1.0.24 and resolving the middleware execution issue, we discovered that `LiftError` objects with specific status codes were being returned as HTTP 500 instead of their intended status codes (e.g., 401, 400, 404).
+
+## Environment
+
+- **lift version**: v1.0.24
+- **Go version**: 1.23.10
+- **AWS Lambda Runtime**: provided.al2
+- **Deployment**: AWS Lambda + API Gateway (REST API)
+
+## Issue Description
+
+When middleware or handlers return `LiftError` objects with specific status codes, the HTTP response always returns status 500 instead of the intended status code. However, the error logging and middleware execution work correctly.
+
+## Expected Behavior
+
+When returning a `LiftError` with a specific status code, the HTTP response should use that status code:
+
+```go
+// This should result in HTTP 401
+return lift.NewLiftError("UNAUTHORIZED", "No API key provided", 401)
+
+// This should result in HTTP 400  
+return lift.NewLiftError("BAD_REQUEST", "Invalid input", 400)
+
+// This should result in HTTP 404
+return lift.NewLiftError("NOT_FOUND", "Resource not found", 404)
+```
+
+## Actual Behavior
+
+All `LiftError` returns result in HTTP 500 responses, regardless of the specified status code.
+
+## Evidence
+
+### CloudWatch Logs (Correct)
+The logs show the errors are being processed correctly with proper error codes:
+```
+2025/06/29 01:24:15 [REQUEST] GET /customers
+2025/06/29 01:24:15 [ERROR] GET /customers - [UNAUTHORIZED] No API key provided (took 19.453µs)
+```
+
+### HTTP Response (Incorrect)
+```bash
+$ curl -v https://api.example.com/v1/customers
+< HTTP/2 500 
+< content-type: application/json
+< content-length: 33
+< 
+{"error":"Internal server error"}
+```
+
+### Expected HTTP Response
+```bash
+$ curl -v https://api.example.com/v1/customers
+< HTTP/2 401 
+< content-type: application/json
+< 
+{"code":"UNAUTHORIZED","message":"No API key provided"}
+```
+
+## Code Examples
+
+### Middleware Implementation
+```go
+func APIKeyAuth() lift.Middleware {
+    return func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            authHeader := ctx.Header("Authorization")
+            if authHeader == "" {
+                // This should return HTTP 401, but returns HTTP 500
+                return lift.NewLiftError("UNAUTHORIZED", "No API key provided", 401)
+            }
+            
+            if !isValidAPIKey(authHeader) {
+                // This should return HTTP 401, but returns HTTP 500
+                return lift.NewLiftError("UNAUTHORIZED", "Invalid API key format", 401)
+            }
+            
+            return next.Handle(ctx)
+        })
+    }
+}
+```
+
+### Handler Implementation
+```go
+func GetUser(ctx *lift.Context) error {
+    userID := ctx.Param("id")
+    if userID == "" {
+        // This should return HTTP 400, but returns HTTP 500
+        return lift.NewLiftError("BAD_REQUEST", "User ID is required", 400)
+    }
+    
+    user, err := getUserFromDB(userID)
+    if err == sql.ErrNoRows {
+        // This should return HTTP 404, but returns HTTP 500
+        return lift.NewLiftError("NOT_FOUND", "User not found", 404)
+    }
+    
+    return ctx.JSON(user)
+}
+```
+
+## Verification Steps
+
+1. **Middleware is executing correctly**: CloudWatch logs show proper error codes and messages
+2. **CORS headers are set**: Response includes proper CORS headers from middleware
+3. **Request ID headers are set**: Response includes `X-Request-ID` from middleware
+4. **Error messages are processed**: Logs show the exact error codes and messages from `LiftError`
+
+This confirms that:
+- ✅ Middleware execution is working (fixed in v1.0.24)
+- ✅ Error creation and logging is working
+- ❌ HTTP status code mapping is not working
+
+## Impact
+
+- **API consumers receive misleading status codes**: All errors appear as server errors (500) instead of client errors (4xx)
+- **Error handling complexity**: Clients cannot distinguish between different error types
+- **Monitoring issues**: 500 errors trigger alerts for server issues when they're actually client errors
+- **HTTP standard compliance**: Violates HTTP status code semantics
+
+## Reproduction Steps
+
+1. Create a simple Lambda with lift v1.0.24:
+```go
+func main() {
+    app := lift.New()
+    
+    app.Use(func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            return lift.NewLiftError("UNAUTHORIZED", "Test error", 401)
+        })
+    })
+    
+    app.GET("/test", func(ctx *lift.Context) error {
+        return ctx.JSON(map[string]string{"status": "ok"})
+    })
+    
+    lambda.Start(app.HandleRequest)
+}
+```
+
+2. Deploy to AWS Lambda + API Gateway
+3. Make request: `curl -v https://api-url/test`
+4. Observe: HTTP 500 instead of HTTP 401
+
+## Additional Context
+
+- This issue appears to be introduced in lift v1.0.24 or is related to the new error handling system
+- The `LiftError` struct correctly contains the status code in the `StatusCode` field
+- Error logging middleware correctly extracts and logs the status code
+- Only the final HTTP response status code mapping is incorrect
+
+## Suggested Investigation Areas
+
+1. **Response building**: Check how `LiftError.StatusCode` is mapped to HTTP response status
+2. **Error middleware**: Verify if built-in error handling middleware is overriding status codes
+3. **API Gateway integration**: Ensure Lambda response format includes proper `statusCode` field
+4. **Context error handling**: Check if `ctx.Status()` is being called with the `LiftError.StatusCode`
+
+## Related Working Features
+
+These features work correctly and confirm the framework is functioning:
+- Middleware execution order
+- Error logging with correct codes
+- CORS header setting
+- Request ID generation
+- Error message formatting
+
+## ✅ Resolution Details
+
+### Root Cause
+The issue was in the `handleError` method in `pkg/lift/app.go`. The method was always returning HTTP 500 status code regardless of the `LiftError.StatusCode` value because it was not checking if the error was a `LiftError` type.
+
+### Fix Applied
+Updated the `handleError` method to:
+1. Check if the error is a `*LiftError` using type assertion
+2. Extract the status code from `LiftError.StatusCode` 
+3. Build a proper error response with code, message, and details
+4. Set the HTTP status code correctly
+
+### Code Changes
+```go
+// handleError processes errors and returns appropriate responses
+func (a *App) handleError(ctx *Context, err error) (any, error) {
+	// Handle Lift errors properly by setting appropriate status codes
+	if liftErr, ok := err.(*LiftError); ok {
+		resp := map[string]any{
+			"code":    liftErr.Code,
+			"message": liftErr.Message,
+		}
+		
+		// Include details if present
+		if len(liftErr.Details) > 0 {
+			resp["details"] = liftErr.Details
+		}
+		
+		ctx.Status(liftErr.StatusCode).JSON(resp)
+		return ctx.Response, nil
+	}
+
+	// For non-Lift errors, set 500 status
+	ctx.Status(500).JSON(map[string]string{
+		"error": "Internal server error",
+	})
+
+	return ctx.Response, nil
+}
+```
+
+### Test Coverage
+Added comprehensive tests in `pkg/lift/app_error_handling_test.go` to verify:
+- ✅ 400, 401, 404, 409 status codes are properly set
+- ✅ Error codes and messages are included in response
+- ✅ Details are included when present
+- ✅ Non-LiftError objects still return 500
+- ✅ Middleware errors are handled correctly
+
+### Verification
+All test cases now pass:
+- `lift.NewLiftError("UNAUTHORIZED", "No API key provided", 401)` → HTTP 401
+- `lift.NewLiftError("BAD_REQUEST", "Invalid input", 400)` → HTTP 400  
+- `lift.NewLiftError("NOT_FOUND", "Resource not found", 404)` → HTTP 404
+- `lift.NewLiftError("CONFLICT", "Resource exists", 409)` → HTTP 409
+
+### Impact
+This fix ensures that:
+- ✅ LiftError.StatusCode is properly mapped to HTTP response status
+- ✅ Error details are included in the response body
+- ✅ Both test and production paths work consistently
+- ✅ API consumers receive correct HTTP status codes
+- ✅ Monitoring systems get accurate error classifications

--- a/lift-error-handling-guide.md
+++ b/lift-error-handling-guide.md
@@ -1,0 +1,667 @@
+# Lift Error Handling Guide
+
+## Table of Contents
+1. [Overview](#overview)
+2. [The LiftError Type](#the-lifterror-type)
+3. [Creating Errors](#creating-errors)
+4. [Common Error Patterns](#common-error-patterns)
+5. [Error Handling in Middleware](#error-handling-in-middleware)
+6. [Error Handling in Handlers](#error-handling-in-handlers)
+7. [Testing Error Scenarios](#testing-error-scenarios)
+8. [Migration from Old API](#migration-from-old-api)
+9. [Best Practices](#best-practices)
+
+## Overview
+
+Lift provides a structured error handling system that ensures consistent error responses across your application. The system is designed to:
+- Provide consistent error formats
+- Support proper HTTP status codes
+- Enable detailed error information for debugging
+- Maintain security by not exposing sensitive information
+- Work seamlessly with middleware chains
+
+## The LiftError Type
+
+### Structure
+
+```go
+type LiftError struct {
+    Code       string                 `json:"code"`
+    Message    string                 `json:"message"`
+    StatusCode int                    `json:"-"`
+    Details    map[string]interface{} `json:"details,omitempty"`
+    Cause      error                  `json:"-"`
+}
+```
+
+### Key Features
+- **Code**: A machine-readable error code (e.g., "VALIDATION_ERROR", "NOT_FOUND")
+- **Message**: A human-readable error message
+- **StatusCode**: HTTP status code for the response
+- **Details**: Optional additional information about the error
+- **Cause**: The underlying error (not exposed in JSON responses)
+
+## Creating Errors
+
+### Basic Error Creation
+
+```go
+// Create a simple error
+err := lift.NewLiftError("NOT_FOUND", "Resource not found", 404)
+
+// Create error with details
+err := lift.NewLiftError("VALIDATION_ERROR", "Invalid request data", 400).
+    WithDetail("field", "email").
+    WithDetail("reason", "invalid format")
+
+// Create error with underlying cause
+err := lift.NewLiftError("DB_ERROR", "Database operation failed", 500).
+    WithCause(dbErr)
+```
+
+### Using Context Error Methods
+
+```go
+func handler(ctx *lift.Context) error {
+    // Client errors (4xx)
+    ctx.BadRequest("Invalid input")
+    ctx.Unauthorized("Authentication required")
+    ctx.Forbidden("Access denied")
+    ctx.NotFound("Resource not found")
+    
+    // Server errors (5xx)
+    ctx.SystemError("Internal error", err)
+    
+    // Custom status codes
+    ctx.Error(409, "CONFLICT", "Resource already exists")
+}
+```
+
+## Common Error Patterns
+
+### Validation Errors
+
+```go
+func CreateUser(ctx *lift.Context) error {
+    var req CreateUserRequest
+    if err := ctx.ParseRequest(&req); err != nil {
+        return lift.NewLiftError("VALIDATION_ERROR", "Invalid request body", 400).
+            WithCause(err)
+    }
+    
+    // Manual validation
+    if req.Age < 0 || req.Age > 120 {
+        return lift.NewLiftError("VALIDATION_ERROR", "Invalid age", 400).
+            WithDetail("field", "age").
+            WithDetail("min", 0).
+            WithDetail("max", 120)
+    }
+    
+    // Or use ValidationError helper
+    if req.Email == "" {
+        return lift.ValidationError("Email is required").
+            WithDetail("field", "email")
+    }
+    
+    // Success case
+    return ctx.JSON(map[string]string{"id": "user_123"})
+}
+```
+
+### Database Errors
+
+```go
+func GetUser(ctx *lift.Context) error {
+    userID := ctx.Param("id")
+    
+    user, err := db.GetUser(userID)
+    if err != nil {
+        if err == sql.ErrNoRows {
+            return lift.NewLiftError("NOT_FOUND", "User not found", 404).
+                WithDetail("user_id", userID)
+        }
+        
+        // Don't expose database errors to clients
+        return lift.NewLiftError("DB_ERROR", "Failed to retrieve user", 500).
+            WithCause(err) // Logged but not exposed
+    }
+    
+    return ctx.JSON(user)
+}
+```
+
+### External Service Errors
+
+```go
+func CallExternalAPI(ctx *lift.Context) error {
+    resp, err := http.Get("https://api.example.com/data")
+    if err != nil {
+        return lift.NewLiftError("EXTERNAL_SERVICE_ERROR", 
+            "Failed to connect to external service", 503).
+            WithCause(err).
+            WithDetail("service", "example-api")
+    }
+    
+    if resp.StatusCode >= 400 {
+        return lift.NewLiftError("EXTERNAL_SERVICE_ERROR",
+            "External service returned error", 502).
+            WithDetail("service", "example-api").
+            WithDetail("status", resp.StatusCode)
+    }
+    
+    // Process response...
+    return nil
+}
+```
+
+### Business Logic Errors
+
+```go
+func TransferFunds(ctx *lift.Context) error {
+    var req TransferRequest
+    if err := ctx.ParseRequest(&req); err != nil {
+        return err
+    }
+    
+    // Check business rules
+    balance, err := getAccountBalance(req.FromAccount)
+    if err != nil {
+        return lift.NewLiftError("ACCOUNT_ERROR", 
+            "Failed to retrieve account balance", 500).
+            WithCause(err)
+    }
+    
+    if balance < req.Amount {
+        return lift.NewLiftError("INSUFFICIENT_FUNDS",
+            "Insufficient funds for transfer", 400).
+            WithDetail("available", balance).
+            WithDetail("requested", req.Amount)
+    }
+    
+    // Process transfer...
+    return ctx.JSON(map[string]string{"status": "completed"})
+}
+```
+
+## Error Handling in Middleware
+
+### Error Recovery Middleware
+
+```go
+func ErrorRecoveryMiddleware() lift.Middleware {
+    return func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            defer func() {
+                if r := recover(); r != nil {
+                    // Log the panic
+                    if ctx.Logger != nil {
+                        ctx.Logger.Error("Handler panicked", map[string]any{
+                            "panic": r,
+                            "stack": string(debug.Stack()),
+                        })
+                    }
+                    
+                    // Return a safe error response
+                    err := lift.NewLiftError("INTERNAL_ERROR", 
+                        "An unexpected error occurred", 500)
+                    ctx.Status(err.StatusCode).JSON(err)
+                }
+            }()
+            
+            return next.Handle(ctx)
+        })
+    }
+}
+```
+
+### Error Logging Middleware
+
+```go
+func ErrorLoggingMiddleware() lift.Middleware {
+    return func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            err := next.Handle(ctx)
+            if err != nil {
+                // Log error details
+                if ctx.Logger != nil {
+                    fields := map[string]any{
+                        "error": err.Error(),
+                        "path": ctx.Request.Path,
+                        "method": ctx.Request.Method,
+                    }
+                    
+                    // Add LiftError details if available
+                    if liftErr, ok := err.(*lift.LiftError); ok {
+                        fields["error_code"] = liftErr.Code
+                        fields["status_code"] = liftErr.StatusCode
+                        if liftErr.Cause != nil {
+                            fields["cause"] = liftErr.Cause.Error()
+                        }
+                    }
+                    
+                    ctx.Logger.Error("Request failed", fields)
+                }
+            }
+            return err
+        })
+    }
+}
+```
+
+### Error Transformation Middleware
+
+```go
+func ErrorTransformationMiddleware() lift.Middleware {
+    return func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            err := next.Handle(ctx)
+            if err == nil {
+                return nil
+            }
+            
+            // Transform specific errors
+            switch {
+            case errors.Is(err, sql.ErrNoRows):
+                return lift.NewLiftError("NOT_FOUND", "Resource not found", 404)
+                
+            case errors.Is(err, context.DeadlineExceeded):
+                return lift.NewLiftError("TIMEOUT", "Request timeout", 504)
+                
+            case errors.Is(err, ErrUnauthorized):
+                return lift.NewLiftError("UNAUTHORIZED", "Authentication required", 401)
+                
+            default:
+                // Return as-is if already a LiftError
+                if _, ok := err.(*lift.LiftError); ok {
+                    return err
+                }
+                
+                // Wrap unknown errors
+                return lift.NewLiftError("INTERNAL_ERROR", 
+                    "An error occurred", 500).WithCause(err)
+            }
+        })
+    }
+}
+```
+
+## Error Handling in Handlers
+
+### Automatic Error Handling
+
+```go
+// Lift automatically handles errors returned from handlers
+func GetUserHandler(ctx *lift.Context) error {
+    user, err := getUserFromDB(ctx.Param("id"))
+    if err != nil {
+        // This error will be caught by the framework
+        return lift.NewLiftError("NOT_FOUND", "User not found", 404)
+    }
+    
+    return ctx.JSON(user)
+}
+```
+
+### Manual Error Handling
+
+```go
+// Sometimes you want to handle errors within the handler
+func ComplexHandler(ctx *lift.Context) error {
+    // Try primary data source
+    data, err := getPrimaryData()
+    if err != nil {
+        // Log error but try fallback
+        if ctx.Logger != nil {
+            ctx.Logger.Warn("Primary data source failed", map[string]any{
+                "error": err.Error(),
+            })
+        }
+        
+        // Try fallback
+        data, err = getFallbackData()
+        if err != nil {
+            // Both failed, return error
+            return lift.NewLiftError("DATA_ERROR", 
+                "Failed to retrieve data", 503).WithCause(err)
+        }
+    }
+    
+    return ctx.JSON(data)
+}
+```
+
+### Type-Safe Handler Errors
+
+```go
+// Using SimpleHandler with automatic error handling
+app.POST("/users", lift.SimpleHandler(func(ctx *lift.Context, req CreateUserRequest) (UserResponse, error) {
+    // Validation is automatic via struct tags
+    
+    // Business logic error
+    if exists := checkUserExists(req.Email); exists {
+        return UserResponse{}, lift.NewLiftError("USER_EXISTS", 
+            "User with this email already exists", 409).
+            WithDetail("email", req.Email)
+    }
+    
+    user, err := createUser(req)
+    if err != nil {
+        return UserResponse{}, lift.NewLiftError("CREATE_ERROR",
+            "Failed to create user", 500).WithCause(err)
+    }
+    
+    return UserResponse{
+        ID:    user.ID,
+        Email: user.Email,
+    }, nil
+}))
+```
+
+## Testing Error Scenarios
+
+### Unit Testing Errors
+
+```go
+func TestErrorHandling(t *testing.T) {
+    app := lift.New()
+    
+    // Handler that returns various errors
+    app.GET("/error/:type", func(ctx *lift.Context) error {
+        errorType := ctx.Param("type")
+        
+        switch errorType {
+        case "validation":
+            return lift.ValidationError("Invalid input").
+                WithDetail("field", "email")
+        case "notfound":
+            return lift.NewLiftError("NOT_FOUND", "Resource not found", 404)
+        case "panic":
+            panic("test panic")
+        default:
+            return nil
+        }
+    })
+    
+    // Add error recovery middleware
+    app.Use(ErrorRecoveryMiddleware())
+    
+    tests := []struct {
+        name           string
+        errorType      string
+        expectedStatus int
+        expectedCode   string
+    }{
+        {
+            name:           "validation error",
+            errorType:      "validation",
+            expectedStatus: 400,
+            expectedCode:   "VALIDATION_ERROR",
+        },
+        {
+            name:           "not found error",
+            errorType:      "notfound",
+            expectedStatus: 404,
+            expectedCode:   "NOT_FOUND",
+        },
+        {
+            name:           "panic recovery",
+            errorType:      "panic",
+            expectedStatus: 500,
+            expectedCode:   "INTERNAL_ERROR",
+        },
+    }
+    
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            ctx := createTestContext("GET", "/error/"+tt.errorType, nil)
+            
+            err := app.HandleTestRequest(ctx)
+            
+            assert.NoError(t, err) // Framework handles errors
+            assert.Equal(t, tt.expectedStatus, ctx.Response.StatusCode)
+            
+            var errResp map[string]any
+            json.Unmarshal(ctx.Response.Body.([]byte), &errResp)
+            assert.Equal(t, tt.expectedCode, errResp["code"])
+        })
+    }
+}
+```
+
+### Integration Testing with Error Scenarios
+
+```go
+func TestAPIErrorScenarios(t *testing.T) {
+    app := testing.NewTestApp()
+    
+    // Setup routes
+    app.POST("/api/users", CreateUserHandler)
+    app.GET("/api/users/:id", GetUserHandler)
+    
+    scenarios := []testing.TestScenario{
+        {
+            Name: "missing required fields",
+            Request: func(app *testing.TestApp) *testing.TestResponse {
+                return app.POST("/api/users", map[string]any{
+                    // Missing required email field
+                    "name": "Test User",
+                })
+            },
+            Assertions: func(t *testing.T, resp *testing.TestResponse) {
+                resp.AssertStatus(400)
+                resp.AssertJSONPath("$.code", "VALIDATION_ERROR")
+                resp.AssertJSONPathExists("$.details.field")
+            },
+        },
+        {
+            Name: "duplicate user",
+            Setup: func(app *testing.TestApp) error {
+                // Create initial user
+                resp := app.POST("/api/users", map[string]any{
+                    "email": "test@example.com",
+                    "name": "Test User",
+                })
+                return resp.Error()
+            },
+            Request: func(app *testing.TestApp) *testing.TestResponse {
+                // Try to create duplicate
+                return app.POST("/api/users", map[string]any{
+                    "email": "test@example.com",
+                    "name": "Another User",
+                })
+            },
+            Assertions: func(t *testing.T, resp *testing.TestResponse) {
+                resp.AssertStatus(409)
+                resp.AssertJSONPath("$.code", "USER_EXISTS")
+            },
+        },
+        {
+            Name: "user not found",
+            Request: func(app *testing.TestApp) *testing.TestResponse {
+                return app.GET("/api/users/nonexistent-id")
+            },
+            Assertions: func(t *testing.T, resp *testing.TestResponse) {
+                resp.AssertStatus(404)
+                resp.AssertJSONPath("$.code", "NOT_FOUND")
+            },
+        },
+    }
+    
+    testing.RunScenarios(t, app, scenarios)
+}
+```
+
+## Migration from Old API
+
+### Before (Old API)
+```go
+// Old error functions that no longer exist
+return lift.BadRequest("Invalid input")
+return lift.InternalError("Server error")
+return ctx.InternalError("Error occurred", err)
+return lift.ValidationError("field", "message")
+```
+
+### After (New API)
+```go
+// New error creation
+return lift.NewLiftError("BAD_REQUEST", "Invalid input", 400)
+return lift.NewLiftError("INTERNAL_ERROR", "Server error", 500)
+return ctx.SystemError("Error occurred", err)
+return lift.ValidationError("message").WithDetail("field", "field")
+```
+
+### Migration Table
+
+| Old API | New API |
+|---------|---------|
+| `lift.BadRequest(msg)` | `lift.NewLiftError("BAD_REQUEST", msg, 400)` |
+| `lift.InternalError(msg)` | `lift.NewLiftError("INTERNAL_ERROR", msg, 500)` |
+| `ctx.InternalError(msg, err)` | `ctx.SystemError(msg, err)` |
+| `lift.ValidationError(field, msg)` | `lift.ValidationError(msg).WithDetail("field", field)` |
+| `lift.NotFound(msg)` | `lift.NewLiftError("NOT_FOUND", msg, 404)` |
+| `lift.Unauthorized(msg)` | `lift.NewLiftError("UNAUTHORIZED", msg, 401)` |
+
+## Best Practices
+
+### 1. Use Consistent Error Codes
+
+```go
+// Define error codes as constants
+const (
+    ErrCodeValidation     = "VALIDATION_ERROR"
+    ErrCodeNotFound       = "NOT_FOUND"
+    ErrCodeUnauthorized   = "UNAUTHORIZED"
+    ErrCodeForbidden      = "FORBIDDEN"
+    ErrCodeConflict       = "CONFLICT"
+    ErrCodeInternal       = "INTERNAL_ERROR"
+    ErrCodeExternalAPI    = "EXTERNAL_API_ERROR"
+    ErrCodeTimeout        = "TIMEOUT"
+    ErrCodeRateLimit      = "RATE_LIMIT_EXCEEDED"
+)
+
+// Use consistently
+return lift.NewLiftError(ErrCodeNotFound, "User not found", 404)
+```
+
+### 2. Don't Expose Sensitive Information
+
+```go
+// BAD - Exposes internal details
+return lift.NewLiftError("DB_ERROR", 
+    fmt.Sprintf("Query failed: %v", dbErr), 500)
+
+// GOOD - Generic message with cause for logging
+return lift.NewLiftError("DB_ERROR", 
+    "Failed to retrieve data", 500).
+    WithCause(dbErr) // Logged but not exposed
+```
+
+### 3. Provide Useful Details
+
+```go
+// Provide actionable information
+return lift.NewLiftError("VALIDATION_ERROR", "Invalid date format", 400).
+    WithDetail("field", "start_date").
+    WithDetail("expected_format", "YYYY-MM-DD").
+    WithDetail("received", userInput)
+```
+
+### 4. Handle Errors at the Right Level
+
+```go
+// Repository layer - return raw errors
+func (r *UserRepo) GetUser(id string) (*User, error) {
+    var user User
+    err := r.db.Get(&user, "SELECT * FROM users WHERE id = ?", id)
+    return &user, err // Return raw error
+}
+
+// Service layer - wrap with context
+func (s *UserService) GetUser(id string) (*User, error) {
+    user, err := s.repo.GetUser(id)
+    if err != nil {
+        if err == sql.ErrNoRows {
+            return nil, lift.NewLiftError("NOT_FOUND", 
+                "User not found", 404).
+                WithDetail("user_id", id)
+        }
+        return nil, lift.NewLiftError("DB_ERROR",
+            "Failed to retrieve user", 500).
+            WithCause(err)
+    }
+    return user, nil
+}
+
+// Handler layer - return service errors
+func GetUserHandler(ctx *lift.Context) error {
+    user, err := userService.GetUser(ctx.Param("id"))
+    if err != nil {
+        return err // Service already wrapped the error
+    }
+    return ctx.JSON(user)
+}
+```
+
+### 5. Test Error Paths
+
+```go
+func TestErrorPaths(t *testing.T) {
+    // Test each error condition
+    testCases := []struct {
+        name          string
+        setup         func()
+        expectedError *lift.LiftError
+    }{
+        {
+            name: "database error",
+            setup: func() {
+                mockDB.ExpectError(errors.New("connection lost"))
+            },
+            expectedError: &lift.LiftError{
+                Code:       "DB_ERROR",
+                StatusCode: 500,
+            },
+        },
+        // More test cases...
+    }
+}
+```
+
+### 6. Use Error Middleware
+
+```go
+// Apply error handling middleware globally
+app := lift.New()
+app.Use(middleware.Recover())        // Panic recovery
+app.Use(middleware.ErrorHandler())   // Error transformation
+app.Use(middleware.Logger())         // Error logging
+```
+
+### 7. Document Error Responses
+
+```go
+// Document your API errors
+// @Summary Create user
+// @Description Create a new user account
+// @Success 201 {object} UserResponse
+// @Failure 400 {object} lift.LiftError "Validation error"
+// @Failure 409 {object} lift.LiftError "User already exists"
+// @Failure 500 {object} lift.LiftError "Internal server error"
+func CreateUserHandler(ctx *lift.Context) error {
+    // Implementation...
+}
+```
+
+## Summary
+
+The Lift error handling system provides:
+
+1. **Structured Errors**: Consistent error format with codes, messages, and details
+2. **Type Safety**: Compile-time checks prevent errors
+3. **Security**: Sensitive information is logged but not exposed
+4. **Flexibility**: Errors can be created and transformed at any layer
+5. **Testing**: Easy to test error scenarios
+6. **Middleware Integration**: Errors flow naturally through middleware chains
+
+By following these patterns and best practices, you can build robust error handling that provides great developer experience and clear feedback to API consumers.

--- a/lift-middleware-testing-guide.md
+++ b/lift-middleware-testing-guide.md
@@ -1,0 +1,691 @@
+# Lift Middleware Testing Guide for Mockery
+
+## Table of Contents
+1. [Understanding Lift Middleware](#understanding-lift-middleware)
+2. [Creating Custom Middleware](#creating-custom-middleware)
+3. [Middleware Execution Order](#middleware-execution-order)
+4. [Testing Middleware](#testing-middleware)
+5. [Common Middleware Patterns](#common-middleware-patterns)
+6. [Troubleshooting](#troubleshooting)
+7. [Best Practices](#best-practices)
+
+## Understanding Lift Middleware
+
+### What is Middleware?
+
+Middleware in Lift is a function that wraps handler execution, allowing you to:
+- Execute code before and/or after handlers
+- Modify requests and responses
+- Short-circuit request processing
+- Share data between middleware and handlers via context
+
+### Middleware Signature
+
+```go
+type Middleware func(Handler) Handler
+type Handler interface {
+    Handle(ctx *Context) error
+}
+```
+
+## Creating Custom Middleware
+
+### Basic Middleware Structure
+
+```go
+func MyMiddleware() lift.Middleware {
+    return func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            // Pre-processing
+            log.Println("Before handler")
+            
+            // Call next handler
+            err := next.Handle(ctx)
+            
+            // Post-processing
+            log.Println("After handler")
+            
+            return err
+        })
+    }
+}
+```
+
+### Middleware with Configuration
+
+```go
+func RateLimitMiddleware(limit int, window time.Duration) lift.Middleware {
+    limiter := NewRateLimiter(limit, window)
+    
+    return func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            key := ctx.Header("X-API-Key")
+            if !limiter.Allow(key) {
+                return lift.NewLiftError("RATE_LIMIT_EXCEEDED", "Too many requests", 429)
+            }
+            return next.Handle(ctx)
+        })
+    }
+}
+```
+
+### Middleware that Sets Context Values
+
+```go
+func DatabaseMiddleware(db *sql.DB) lift.Middleware {
+    return func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            // Set database in context
+            ctx.Set("db", db)
+            
+            // Set up transaction if needed
+            tx, err := db.BeginTx(ctx, nil)
+            if err != nil {
+                return lift.NewLiftError("DB_ERROR", "Failed to start transaction", 500).WithCause(err)
+            }
+            
+            ctx.Set("tx", tx)
+            
+            // Execute handler
+            err = next.Handle(ctx)
+            
+            // Commit or rollback based on error
+            if err != nil {
+                tx.Rollback()
+                return err
+            }
+            
+            if err := tx.Commit(); err != nil {
+                return lift.NewLiftError("DB_ERROR", "Failed to commit transaction", 500).WithCause(err)
+            }
+            
+            return nil
+        })
+    }
+}
+```
+
+## Middleware Execution Order
+
+### Registration Order Matters
+
+```go
+app := lift.New()
+
+// Middleware executes in the order registered
+app.Use(RecoveryMiddleware())    // 1st - Catches panics
+app.Use(LoggingMiddleware())      // 2nd - Logs all requests
+app.Use(AuthMiddleware())         // 3rd - Authenticates
+app.Use(DatabaseMiddleware())     // 4th - Sets up DB
+
+// Handler executes last
+app.GET("/users", GetUsers)
+```
+
+### Execution Flow
+
+```
+Request → Recovery → Logging → Auth → Database → Handler
+                                                      ↓
+Response ← Recovery ← Logging ← Auth ← Database ←────┘
+```
+
+## Testing Middleware
+
+### Unit Testing Individual Middleware
+
+```go
+func TestAuthMiddleware(t *testing.T) {
+    // Create middleware
+    authMiddleware := AuthMiddleware("secret-key")
+    
+    // Create a mock handler to verify it's called
+    handlerCalled := false
+    mockHandler := lift.HandlerFunc(func(ctx *lift.Context) error {
+        handlerCalled = true
+        // Verify context values were set
+        assert.Equal(t, "user123", ctx.UserID())
+        assert.Equal(t, "tenant456", ctx.TenantID())
+        return nil
+    })
+    
+    // Wrap handler with middleware
+    wrappedHandler := authMiddleware(mockHandler)
+    
+    // Create test context with valid token
+    ctx := createTestContext("GET", "/test", nil)
+    ctx.Request.Headers["Authorization"] = "Bearer valid-token"
+    
+    // Execute
+    err := wrappedHandler.Handle(ctx)
+    
+    // Assertions
+    assert.NoError(t, err)
+    assert.True(t, handlerCalled)
+}
+
+func TestAuthMiddlewareInvalidToken(t *testing.T) {
+    authMiddleware := AuthMiddleware("secret-key")
+    
+    handlerCalled := false
+    mockHandler := lift.HandlerFunc(func(ctx *lift.Context) error {
+        handlerCalled = true
+        return nil
+    })
+    
+    wrappedHandler := authMiddleware(mockHandler)
+    
+    // Test with invalid token
+    ctx := createTestContext("GET", "/test", nil)
+    ctx.Request.Headers["Authorization"] = "Bearer invalid-token"
+    
+    err := wrappedHandler.Handle(ctx)
+    
+    // Should return error and not call handler
+    assert.Error(t, err)
+    assert.False(t, handlerCalled)
+    
+    // Verify error type
+    liftErr, ok := err.(*lift.LiftError)
+    assert.True(t, ok)
+    assert.Equal(t, 401, liftErr.StatusCode)
+}
+```
+
+### Integration Testing with Multiple Middleware
+
+```go
+func TestMiddlewareChain(t *testing.T) {
+    app := lift.New()
+    
+    // Track execution order
+    var executionOrder []string
+    
+    // Add middleware that tracks execution
+    app.Use(func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            executionOrder = append(executionOrder, "middleware1-before")
+            err := next.Handle(ctx)
+            executionOrder = append(executionOrder, "middleware1-after")
+            return err
+        })
+    })
+    
+    app.Use(func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            executionOrder = append(executionOrder, "middleware2-before")
+            err := next.Handle(ctx)
+            executionOrder = append(executionOrder, "middleware2-after")
+            return err
+        })
+    })
+    
+    // Add handler
+    app.GET("/test", func(ctx *lift.Context) error {
+        executionOrder = append(executionOrder, "handler")
+        return ctx.JSON(map[string]string{"status": "ok"})
+    })
+    
+    // Create test context
+    ctx := createTestContext("GET", "/test", nil)
+    
+    // Execute through app
+    err := app.HandleTestRequest(ctx)
+    
+    // Verify
+    assert.NoError(t, err)
+    assert.Equal(t, []string{
+        "middleware1-before",
+        "middleware2-before",
+        "handler",
+        "middleware2-after",
+        "middleware1-after",
+    }, executionOrder)
+}
+```
+
+### Testing Middleware Error Handling
+
+```go
+func TestMiddlewareErrorPropagation(t *testing.T) {
+    app := lift.New()
+    
+    // Middleware that logs errors
+    errorLogged := false
+    app.Use(func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            err := next.Handle(ctx)
+            if err != nil {
+                errorLogged = true
+            }
+            return err
+        })
+    })
+    
+    // Handler that returns error
+    app.GET("/error", func(ctx *lift.Context) error {
+        return lift.NewLiftError("TEST_ERROR", "Something went wrong", 500)
+    })
+    
+    ctx := createTestContext("GET", "/error", nil)
+    err := app.HandleTestRequest(ctx)
+    
+    // Error should be handled by framework, not returned
+    assert.NoError(t, err)
+    assert.True(t, errorLogged)
+    assert.Equal(t, 500, ctx.Response.StatusCode)
+}
+```
+
+### Testing Context Value Propagation
+
+```go
+func TestMiddlewareContextValues(t *testing.T) {
+    app := lift.New()
+    
+    // Middleware sets values
+    app.Use(func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            ctx.Set("service", &MyService{Name: "test-service"})
+            ctx.Set("request-id", "req-123")
+            return next.Handle(ctx)
+        })
+    })
+    
+    // Handler uses values
+    app.GET("/test", func(ctx *lift.Context) error {
+        service := ctx.Get("service").(*MyService)
+        requestID := ctx.Get("request-id").(string)
+        
+        return ctx.JSON(map[string]string{
+            "service": service.Name,
+            "request_id": requestID,
+        })
+    })
+    
+    ctx := createTestContext("GET", "/test", nil)
+    err := app.HandleTestRequest(ctx)
+    
+    assert.NoError(t, err)
+    assert.Equal(t, 200, ctx.Response.StatusCode)
+    
+    // Verify response
+    var resp map[string]string
+    json.Unmarshal(ctx.Response.Body.([]byte), &resp)
+    assert.Equal(t, "test-service", resp["service"])
+    assert.Equal(t, "req-123", resp["request_id"])
+}
+```
+
+## Common Middleware Patterns
+
+### Authentication Middleware
+
+```go
+func JWTAuthMiddleware(secretKey string) lift.Middleware {
+    return func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            // Skip auth for public endpoints
+            if isPublicEndpoint(ctx.Request.Path) {
+                return next.Handle(ctx)
+            }
+            
+            // Extract token
+            authHeader := ctx.Header("Authorization")
+            if authHeader == "" {
+                return lift.NewLiftError("UNAUTHORIZED", "Missing authorization header", 401)
+            }
+            
+            tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+            
+            // Validate token
+            token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+                return []byte(secretKey), nil
+            })
+            
+            if err != nil || !token.Valid {
+                return lift.NewLiftError("UNAUTHORIZED", "Invalid token", 401)
+            }
+            
+            // Extract claims and set in context
+            if claims, ok := token.Claims.(jwt.MapClaims); ok {
+                ctx.SetClaims(claims)
+            }
+            
+            return next.Handle(ctx)
+        })
+    }
+}
+```
+
+### Request ID Middleware
+
+```go
+func RequestIDMiddleware() lift.Middleware {
+    return func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            requestID := ctx.Header("X-Request-ID")
+            if requestID == "" {
+                requestID = generateRequestID()
+            }
+            
+            ctx.SetRequestID(requestID)
+            ctx.Response.Header("X-Request-ID", requestID)
+            
+            return next.Handle(ctx)
+        })
+    }
+}
+```
+
+### Metrics Middleware
+
+```go
+func MetricsMiddleware(collector MetricsCollector) lift.Middleware {
+    return func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            start := time.Now()
+            
+            // Execute handler
+            err := next.Handle(ctx)
+            
+            // Record metrics
+            duration := time.Since(start)
+            labels := map[string]string{
+                "method": ctx.Request.Method,
+                "path":   ctx.Request.Path,
+                "status": fmt.Sprintf("%d", ctx.Response.StatusCode),
+            }
+            
+            collector.RecordDuration("http_request_duration", duration, labels)
+            collector.IncrementCounter("http_requests_total", labels)
+            
+            if err != nil {
+                collector.IncrementCounter("http_errors_total", labels)
+            }
+            
+            return err
+        })
+    }
+}
+```
+
+## Troubleshooting
+
+### Common Issues and Solutions
+
+#### 1. Middleware Not Executing
+
+**Problem**: Middleware doesn't seem to run in Lambda
+```go
+// WRONG - Middleware won't be transferred
+lambda.Start(app.HandleRequest)
+```
+
+**Solution**: Ensure app.Start() is called (fixed in latest version)
+```go
+// The fix ensures Start() is called internally
+lambda.Start(app.HandleRequest) // Now works correctly
+```
+
+#### 2. Context Values Not Available
+
+**Problem**: Handler can't access values set by middleware
+```go
+// Middleware sets value
+ctx.Set("user", user)
+
+// Handler gets nil
+user := ctx.Get("user") // nil
+```
+
+**Solution**: Ensure middleware is registered before routes
+```go
+app := lift.New()
+app.Use(AuthMiddleware()) // Register middleware first
+app.GET("/users", handler) // Then register routes
+```
+
+#### 3. Middleware Order Issues
+
+**Problem**: Dependencies between middleware not respected
+```go
+// WRONG - DB middleware needs auth context
+app.Use(DatabaseMiddleware()) // Needs tenant ID
+app.Use(AuthMiddleware())     // Sets tenant ID
+```
+
+**Solution**: Register in dependency order
+```go
+// CORRECT
+app.Use(AuthMiddleware())     // Sets tenant ID first
+app.Use(DatabaseMiddleware()) // Can now use tenant ID
+```
+
+## Best Practices
+
+### 1. Keep Middleware Focused
+
+Each middleware should have a single responsibility:
+```go
+// GOOD - Single responsibility
+app.Use(AuthenticationMiddleware())
+app.Use(AuthorizationMiddleware())
+app.Use(LoggingMiddleware())
+
+// BAD - Doing too much
+app.Use(AuthAndLoggingAndMetricsMiddleware())
+```
+
+### 2. Handle Errors Gracefully
+
+```go
+func SafeMiddleware() lift.Middleware {
+    return func(next lift.Handler) lift.Handler {
+        return lift.HandlerFunc(func(ctx *lift.Context) error {
+            defer func() {
+                if r := recover(); r != nil {
+                    ctx.Logger.Error("Middleware panic", map[string]any{
+                        "panic": r,
+                        "stack": string(debug.Stack()),
+                    })
+                    ctx.Status(500).JSON(map[string]string{
+                        "error": "Internal server error",
+                    })
+                }
+            }()
+            
+            return next.Handle(ctx)
+        })
+    }
+}
+```
+
+### 3. Use Type-Safe Context Access
+
+```go
+// Define typed getters
+func GetDatabase(ctx *lift.Context) (*sql.DB, error) {
+    db, ok := ctx.Get("db").(*sql.DB)
+    if !ok {
+        return nil, errors.New("database not initialized")
+    }
+    return db, nil
+}
+
+// Use in handlers
+func GetUsers(ctx *lift.Context) error {
+    db, err := GetDatabase(ctx)
+    if err != nil {
+        return lift.NewLiftError("INTERNAL_ERROR", "Database not available", 500)
+    }
+    
+    // Use db safely
+    users, err := db.Query("SELECT * FROM users")
+    // ...
+}
+```
+
+### 4. Test Middleware in Isolation
+
+```go
+func TestMiddleware(t *testing.T) {
+    tests := []struct {
+        name          string
+        setupContext  func(*lift.Context)
+        middleware    lift.Middleware
+        expectError   bool
+        expectContext func(*testing.T, *lift.Context)
+    }{
+        {
+            name: "successful auth",
+            setupContext: func(ctx *lift.Context) {
+                ctx.Request.Headers["Authorization"] = "Bearer valid-token"
+            },
+            middleware:  AuthMiddleware(),
+            expectError: false,
+            expectContext: func(t *testing.T, ctx *lift.Context) {
+                assert.NotEmpty(t, ctx.UserID())
+            },
+        },
+        {
+            name: "missing auth",
+            setupContext: func(ctx *lift.Context) {
+                // No auth header
+            },
+            middleware:  AuthMiddleware(),
+            expectError: true,
+        },
+    }
+    
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            // Setup
+            ctx := createTestContext("GET", "/test", nil)
+            tt.setupContext(ctx)
+            
+            // Create mock handler
+            handler := lift.HandlerFunc(func(ctx *lift.Context) error {
+                return nil
+            })
+            
+            // Apply middleware
+            wrapped := tt.middleware(handler)
+            
+            // Execute
+            err := wrapped.Handle(ctx)
+            
+            // Assert
+            if tt.expectError {
+                assert.Error(t, err)
+            } else {
+                assert.NoError(t, err)
+                if tt.expectContext != nil {
+                    tt.expectContext(t, ctx)
+                }
+            }
+        })
+    }
+}
+```
+
+### 5. Document Middleware Dependencies
+
+```go
+// AuthMiddleware sets the following context values:
+// - "user_id": string
+// - "tenant_id": string
+// - "roles": []string
+//
+// Required headers:
+// - Authorization: Bearer <token>
+func AuthMiddleware() lift.Middleware {
+    // Implementation
+}
+
+// DatabaseMiddleware requires:
+// - "tenant_id" to be set in context (by AuthMiddleware)
+//
+// Sets:
+// - "db": *sql.DB (tenant-scoped database connection)
+func DatabaseMiddleware() lift.Middleware {
+    // Implementation
+}
+```
+
+## Helper Functions for Testing
+
+```go
+// createTestContext creates a test context for middleware testing
+func createTestContext(method, path string, body []byte) *lift.Context {
+    req := &lift.Request{
+        Method:      method,
+        Path:        path,
+        Headers:     make(map[string]string),
+        QueryParams: make(map[string]string),
+        Body:        body,
+    }
+    return lift.NewContext(context.Background(), req)
+}
+
+// assertMiddlewareOrder verifies middleware execution order
+func assertMiddlewareOrder(t *testing.T, app *lift.App, expectedOrder []string) {
+    var actualOrder []string
+    
+    // Add tracking middleware
+    for i, name := range expectedOrder {
+        middlewareName := name // Capture in closure
+        app.Use(func(next lift.Handler) lift.Handler {
+            return lift.HandlerFunc(func(ctx *lift.Context) error {
+                actualOrder = append(actualOrder, middlewareName+"-before")
+                err := next.Handle(ctx)
+                actualOrder = append(actualOrder, middlewareName+"-after")
+                return err
+            })
+        })
+    }
+    
+    // Add handler
+    app.GET("/test", func(ctx *lift.Context) error {
+        actualOrder = append(actualOrder, "handler")
+        return nil
+    })
+    
+    // Execute
+    ctx := createTestContext("GET", "/test", nil)
+    app.HandleTestRequest(ctx)
+    
+    // Build expected full order
+    var expected []string
+    for _, name := range expectedOrder {
+        expected = append(expected, name+"-before")
+    }
+    expected = append(expected, "handler")
+    for i := len(expectedOrder) - 1; i >= 0; i-- {
+        expected = append(expected, expectedOrder[i]+"-after")
+    }
+    
+    assert.Equal(t, expected, actualOrder)
+}
+```
+
+## Summary
+
+Testing Lift middleware effectively requires:
+
+1. **Understanding the execution model** - Middleware wraps handlers in layers
+2. **Testing in isolation** - Unit test individual middleware
+3. **Testing integration** - Verify middleware chains work together
+4. **Testing error cases** - Ensure errors are handled properly
+5. **Testing context propagation** - Verify values pass through correctly
+
+Remember that middleware is just a function that returns a function. This makes it highly testable - you can create mock handlers, control the context, and verify behavior at each step.
+
+The key to successful middleware testing is to:
+- Test each middleware in isolation first
+- Test common combinations
+- Test error propagation
+- Test context value sharing
+- Document dependencies clearly
+
+With these patterns, you can build and test robust middleware for your Lift applications.

--- a/pkg/lift/app.go
+++ b/pkg/lift/app.go
@@ -316,7 +316,23 @@ func (a *App) parseEvent(event any) (*Request, error) {
 
 // handleError processes errors and returns appropriate responses
 func (a *App) handleError(ctx *Context, err error) (any, error) {
-	// Set error response
+	// Handle Lift errors properly by setting appropriate status codes
+	if liftErr, ok := err.(*LiftError); ok {
+		resp := map[string]any{
+			"code":    liftErr.Code,
+			"message": liftErr.Message,
+		}
+		
+		// Include details if present
+		if len(liftErr.Details) > 0 {
+			resp["details"] = liftErr.Details
+		}
+		
+		ctx.Status(liftErr.StatusCode).JSON(resp)
+		return ctx.Response, nil
+	}
+
+	// For non-Lift errors, set 500 status
 	ctx.Status(500).JSON(map[string]string{
 		"error": "Internal server error",
 	})

--- a/pkg/lift/app_error_handling_test.go
+++ b/pkg/lift/app_error_handling_test.go
@@ -1,0 +1,223 @@
+package lift
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pay-theory/lift/pkg/lift/adapters"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleRequestLiftErrorStatusCodes(t *testing.T) {
+	tests := []struct {
+		name           string
+		error          *LiftError
+		expectedStatus int
+		expectedCode   string
+		expectedMsg    string
+		hasDetails     bool
+	}{
+		{
+			name:           "400 Bad Request",
+			error:          NewLiftError("BAD_REQUEST", "Invalid input", 400),
+			expectedStatus: 400,
+			expectedCode:   "BAD_REQUEST",
+			expectedMsg:    "Invalid input",
+			hasDetails:     false,
+		},
+		{
+			name:           "401 Unauthorized",
+			error:          NewLiftError("UNAUTHORIZED", "No API key provided", 401),
+			expectedStatus: 401,
+			expectedCode:   "UNAUTHORIZED",
+			expectedMsg:    "No API key provided",
+			hasDetails:     false,
+		},
+		{
+			name:           "404 Not Found",
+			error:          NewLiftError("NOT_FOUND", "Resource not found", 404),
+			expectedStatus: 404,
+			expectedCode:   "NOT_FOUND",
+			expectedMsg:    "Resource not found",
+			hasDetails:     false,
+		},
+		{
+			name: "400 with Details",
+			error: NewLiftError("VALIDATION_ERROR", "Validation failed", 400).
+				WithDetail("field", "email").
+				WithDetail("reason", "invalid format"),
+			expectedStatus: 400,
+			expectedCode:   "VALIDATION_ERROR",
+			expectedMsg:    "Validation failed",
+			hasDetails:     true,
+		},
+		{
+			name:           "409 Conflict",
+			error:          NewLiftError("CONFLICT", "Resource already exists", 409),
+			expectedStatus: 409,
+			expectedCode:   "CONFLICT",
+			expectedMsg:    "Resource already exists",
+			hasDetails:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := New()
+
+			// Create a handler that returns the specific error
+			app.GET("/test", func(ctx *Context) error {
+				return tt.error
+			})
+
+			// Create test request
+			req := NewRequest(&adapters.Request{
+				Method:      "GET",
+				Path:        "/test",
+				Headers:     make(map[string]string),
+				QueryParams: make(map[string]string),
+				Body:        []byte{},
+				TriggerType: TriggerAPIGateway,
+			})
+
+			// Simulate HandleRequest flow
+			ctx := NewContext(context.Background(), req)
+			
+			// Start the app to transfer middleware
+			err := app.Start()
+			require.NoError(t, err)
+
+			// Handle the request through the router
+			routerErr := app.router.Handle(ctx)
+			require.Error(t, routerErr, "Handler should return an error")
+
+			// Call handleError as HandleRequest would
+			response, err := app.handleError(ctx, routerErr)
+			require.NoError(t, err, "handleError should not return an error")
+			require.NotNil(t, response, "Response should not be nil")
+
+			// Verify status code
+			assert.Equal(t, tt.expectedStatus, ctx.Response.StatusCode,
+				"Status code should match LiftError.StatusCode")
+
+			// Parse response body
+			respBody, ok := ctx.Response.Body.(map[string]any)
+			require.True(t, ok, "Response body should be map[string]any")
+			require.NotNil(t, respBody, "Response body should not be nil")
+
+			// Verify response structure
+			assert.Equal(t, tt.expectedCode, respBody["code"], "Error code should match")
+			assert.Equal(t, tt.expectedMsg, respBody["message"], "Error message should match")
+
+			// Check details if expected
+			if tt.hasDetails {
+				assert.Contains(t, respBody, "details", "Response should contain details")
+				details, ok := respBody["details"].(map[string]any)
+				assert.True(t, ok, "Details should be a map")
+				assert.NotEmpty(t, details, "Details should not be empty")
+			} else {
+				assert.NotContains(t, respBody, "details", "Response should not contain details")
+			}
+		})
+	}
+}
+
+func TestHandleRequestNonLiftError(t *testing.T) {
+	app := New()
+
+	// Create a handler that returns a regular error
+	app.GET("/test", func(ctx *Context) error {
+		return assert.AnError // A regular error, not LiftError
+	})
+
+	// Create test request
+	req := NewRequest(&adapters.Request{
+		Method:      "GET",
+		Path:        "/test",
+		Headers:     make(map[string]string),
+		QueryParams: make(map[string]string),
+		Body:        []byte{},
+		TriggerType: TriggerAPIGateway,
+	})
+
+	// Simulate HandleRequest flow
+	ctx := NewContext(context.Background(), req)
+	
+	// Start the app
+	err := app.Start()
+	require.NoError(t, err)
+
+	// Handle the request
+	routerErr := app.router.Handle(ctx)
+	require.Error(t, routerErr, "Handler should return an error")
+
+	// Call handleError
+	response, err := app.handleError(ctx, routerErr)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	// Should return 500 for non-LiftError
+	assert.Equal(t, 500, ctx.Response.StatusCode)
+
+	// Parse response
+	respBody, ok := ctx.Response.Body.(map[string]string)
+	require.True(t, ok)
+
+	// Should contain generic error message
+	assert.Equal(t, "Internal server error", respBody["error"])
+	assert.NotContains(t, respBody, "code", "Non-LiftError should not have code field")
+}
+
+func TestMiddlewareLiftErrorStatusCodes(t *testing.T) {
+	app := New()
+
+	// Add middleware that returns a LiftError
+	app.Use(func(next Handler) Handler {
+		return HandlerFunc(func(ctx *Context) error {
+			// Simulate auth middleware that fails
+			return NewLiftError("UNAUTHORIZED", "Invalid API key", 401)
+		})
+	})
+
+	// Add a handler (should not be reached)
+	app.GET("/test", func(ctx *Context) error {
+		return ctx.JSON(map[string]string{"status": "ok"})
+	})
+
+	// Create test request
+	req := NewRequest(&adapters.Request{
+		Method:      "GET",
+		Path:        "/test",
+		Headers:     make(map[string]string),
+		QueryParams: make(map[string]string),
+		Body:        []byte{},
+		TriggerType: TriggerAPIGateway,
+	})
+
+	// Simulate HandleRequest flow
+	ctx := NewContext(context.Background(), req)
+	
+	// Start the app
+	err := app.Start()
+	require.NoError(t, err)
+
+	// Handle through router (middleware will fail)
+	routerErr := app.router.Handle(ctx)
+	require.Error(t, routerErr, "Middleware should return an error")
+
+	// Call handleError
+	response, err := app.handleError(ctx, routerErr)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	// Verify status code from middleware error
+	assert.Equal(t, 401, ctx.Response.StatusCode)
+
+	// Parse response
+	respBody, ok := ctx.Response.Body.(map[string]any)
+	require.True(t, ok)
+
+	assert.Equal(t, "UNAUTHORIZED", respBody["code"])
+	assert.Equal(t, "Invalid API key", respBody["message"])
+}


### PR DESCRIPTION
## Summary
Fixes critical issue where `LiftError` objects with specific status codes (401, 400, 404, etc.) were always being returned as HTTP 500 instead of their intended status codes in production Lambda environments.

## Problem
- API consumers received misleading HTTP 500 status codes for client errors (4xx)
- Monitoring systems triggered false alerts for server errors when they were actually client errors
- Error details were not properly exposed in response bodies
- Violated HTTP status code semantics and API contract compliance

## Root Cause
The `handleError` method in `pkg/lift/app.go` was not checking if the error was a `*LiftError` type before processing it, causing all errors to default to HTTP 500 with a generic "Internal server error" message.

## Solution
✅ **Fixed handleError method** to properly type-check for `*LiftError`  
✅ **Extract status code** from `LiftError.StatusCode` and apply to HTTP response  
✅ **Include error details** (code, message, details) in response body  
✅ **Maintain backward compatibility** for non-LiftError types  
✅ **Added comprehensive test coverage** for all error scenarios  

## Changes Made

### Core Fix
- **pkg/lift/app.go**: Updated `handleError` method with proper LiftError handling
- **pkg/lift/app_error_handling_test.go**: Comprehensive test suite for error handling

### Documentation  
- **lift-error-handling-guide.md**: Complete guide for new error handling system
- **lift-middleware-testing-guide.md**: Guide for testing middleware with errors  
- **LIFT_RESPONSE_CODES.md**: Issue documentation and resolution details

## Test Coverage
Added extensive test coverage for:
- ✅ 400, 401, 404, 409 status codes properly mapped
- ✅ Error codes and messages included in response body
- ✅ Error details included when present  
- ✅ Non-LiftError objects still return 500
- ✅ Middleware errors handled correctly

## Before/After

### Before (Broken)
```bash
$ curl -v https://api.example.com/v1/customers
< HTTP/2 500 
< content-type: application/json
{"error":"Internal server error"}
```

### After (Fixed)  
```bash
$ curl -v https://api.example.com/v1/customers
< HTTP/2 401
< content-type: application/json
{"code":"UNAUTHORIZED","message":"No API key provided"}
```

## Impact
- ✅ API consumers receive correct HTTP status codes
- ✅ Monitoring systems get accurate error classifications  
- ✅ Error details properly exposed in response body
- ✅ Both test and production paths work consistently
- ✅ Resolves production API compliance issues

## Testing
```bash
# Run error handling tests
go test ./pkg/lift -run "TestHandleRequest.*Error" -v

# Run full test suite
go test ./pkg/lift -v
```

All tests pass with the new error handling implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)