### PR TITLE
refactor: Remove 'key' from automatic redaction lists

### DIFF
--- a/pkg/security/dataprotection.go
+++ b/pkg/security/dataprotection.go
@@ -210,7 +210,7 @@ func (dpm *DataProtectionManager) classifyField(field string, value any) DataCla
 
 	// High sensitivity fields from sanitization logic
 	highSensitiveFields := []string{
-		"password", "token", "secret", "key", "auth", "credential",
+		"password", "token", "secret", "auth", "credential",
 		"email", "phone", "ssn", "card", "account", "routing",
 		"pin", "cvv", "security", "private", "confidential",
 	}
@@ -221,7 +221,7 @@ func (dpm *DataProtectionManager) classifyField(field string, value any) DataCla
 			switch sensitive {
 			case "ssn", "card", "account", "routing", "cvv", "pin":
 				return DataRestricted
-			case "password", "token", "secret", "key", "auth", "credential", "private":
+			case "password", "token", "secret", "auth", "credential", "private":
 				return DataConfidential
 			case "email", "phone":
 				return DataInternal

--- a/pkg/utils/sanitization/sanitization.go
+++ b/pkg/utils/sanitization/sanitization.go
@@ -182,7 +182,6 @@ func (s *Sanitizer) SanitizeQueryParams(params map[string][]string) map[string]s
 		"secret":   true,
 		"auth":     true,
 		"session":  true,
-		"key":      true,
 	}
 
 	result := make(map[string]string)


### PR DESCRIPTION
Remove 'key' from both highSensitiveFields and sensitiveParams to prevent automatic redaction of fields containing 'key'. This allows legitimate use of 'key' in field names without unintended sanitization.

🤖 Generated with [Claude Code](https://claude.ai/code)