### PR TITLE
Fix DynamoDB multi-tenant table naming for DynamORM compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,34 @@ patterns.NewLiftApp(app, jsii.String("MyApp"), &patterns.LiftAppProps{
 app.Synth(nil)
 ```
 
+### DynamORM Multi-Tenant Pattern
+When `EnableMultiTenant: true`, tables are created with standard `pk`/`sk` naming for DynamORM compatibility. Multi-tenant isolation is achieved through key values:
+
+```go
+type User struct {
+    PK         string `dynamodbav:"pk"`           // tenant#{tenant_id}
+    SK         string `dynamodbav:"sk"`           // user#{user_id}
+    TenantID   string `dynamodbav:"tenant_id"`    // For GSI queries
+    EntityType string `dynamodbav:"entity_type"`  // "user"
+    
+    // Business fields
+    UserID    string `dynamodbav:"user_id"`
+    Email     string `dynamodbav:"email"`
+    Name      string `dynamodbav:"name"`
+}
+
+// Usage
+user := User{
+    PK:         fmt.Sprintf("tenant#%s", tenantID),
+    SK:         fmt.Sprintf("user#%s", userID),
+    TenantID:   tenantID,
+    EntityType: "user",
+    UserID:     userID,
+    Email:      "user@example.com",
+    Name:       "John Doe",
+}
+```
+
 ### CDK Constructs
 - **LiftFunction**: Optimized Lambda with ARM64, tracing, multi-tenant support
 - **LiftAPI**: API Gateway with CORS, custom domains, rate limiting

--- a/pkg/cdk/constructs/dynamodb.go
+++ b/pkg/cdk/constructs/dynamodb.go
@@ -60,10 +60,8 @@ func NewLiftTable(scope constructs.Construct, id *string, props *LiftTableProps)
 		Type: awsdynamodb.AttributeType_STRING,
 	}
 
-	// If multi-tenant, adjust keys
-	if props.EnableMultiTenant != nil && *props.EnableMultiTenant {
-		partitionKey.Name = jsii.String("tenantId#pk")
-	}
+	// Multi-tenant tables use standard 'pk' naming for DynamORM compatibility
+	// Tenant isolation is achieved through key values, not attribute names
 
 	// Create table properties
 	tableProps := &awsdynamodb.TableProps{


### PR DESCRIPTION
## Summary
- Fixes DynamoDB multi-tenant table naming to use standard `pk`/`sk` attributes instead of `tenantId#pk`
- Resolves ValidationException when writing to multi-tenant tables with DynamORM
- Adds documentation for correct DynamORM multi-tenant patterns

## Problem
When `EnableMultiTenant: true` was set in Lift CDK constructs, DynamoDB tables were created with partition key named `tenantId#pk`. This caused DynamORM models to fail with:
```
ValidationException: One or more parameter values were invalid: Missing the key tenantId#pk in the item
```

## Solution
- Remove custom partition key naming in multi-tenant mode
- Use standard `pk`/`sk` naming that DynamORM expects
- Multi-tenant isolation is achieved through key values (e.g., `tenant#123`) rather than attribute names
- Add clear documentation showing the correct DynamORM model structure

## Test Plan
- [ ] Deploy updated CDK construct with EnableMultiTenant: true
- [ ] Verify table is created with pk/sk attributes (not tenantId#pk)
- [ ] Test DynamORM writes succeed with standard model structure
- [ ] Verify multi-tenant isolation still works through key values

🤖 Generated with [Claude Code](https://claude.ai/code)