### PR TITLE
Fix DynamoDB multi-tenant table naming for DynamORM compatibility

### DIFF
--- a/pkg/cdk/constructs/multi_tenant_api.go
+++ b/pkg/cdk/constructs/multi_tenant_api.go
@@ -38,6 +38,12 @@ type MultiTenantAPIProps struct {
 	// Lambda function timeout
 	Timeout awscdk.Duration
 
+	// Existing DynamoDB table (optional - will create one if not provided)
+	Table awsdynamodb.ITable
+
+	// Table name for new table (used if Table is not provided)
+	TableName *string
+
 	// Cognito user pool for authentication
 	UserPool awscognito.IUserPool
 
@@ -115,8 +121,8 @@ type MultiTenantAPI struct {
 	constructs.Construct
 	API            awsapigatewayv2.HttpApi
 	Function       *LiftFunction
-	TenantTable    awsdynamodb.Table
-	RateLimitTable awsdynamodb.Table
+	Table          awsdynamodb.ITable
+	RateLimitTable awsdynamodb.ITable
 	WebACL         awswafv2.CfnWebACL
 }
 
@@ -135,33 +141,34 @@ func NewMultiTenantAPI(scope constructs.Construct, id string, props *MultiTenant
 		props.TenantIDHeader = jsii.String("X-Tenant-ID")
 	}
 
-	// Create tenant tracking table
-	tenantTable := awsdynamodb.NewTable(this, jsii.String("TenantTable"), &awsdynamodb.TableProps{
-		TableName:       jsii.String(fmt.Sprintf("%s-tenants", *props.APIName)),
-		PartitionKey:    &awsdynamodb.Attribute{Name: jsii.String("tenantId"), Type: awsdynamodb.AttributeType_STRING},
-		BillingMode:     awsdynamodb.BillingMode_PAY_PER_REQUEST,
-		PointInTimeRecovery: jsii.Bool(true),
-		Encryption:      awsdynamodb.TableEncryption_AWS_MANAGED,
-		RemovalPolicy:   awscdk.RemovalPolicy_RETAIN,
-	})
-
-	// Add GSI for tenant status
-	tenantTable.AddGlobalSecondaryIndex(&awsdynamodb.GlobalSecondaryIndexProps{
-		IndexName:    jsii.String("status-index"),
-		PartitionKey: &awsdynamodb.Attribute{Name: jsii.String("status"), Type: awsdynamodb.AttributeType_STRING},
-		SortKey:      &awsdynamodb.Attribute{Name: jsii.String("updatedAt"), Type: awsdynamodb.AttributeType_STRING},
-	})
+	// Use existing table or create a DynamORM-compatible one
+	var table awsdynamodb.ITable
+	if props.Table != nil {
+		table = props.Table
+	} else {
+		// Create a DynamORM-compatible multi-tenant table
+		tableName := props.TableName
+		if tableName == nil {
+			tableName = jsii.String(fmt.Sprintf("%s-table", *props.APIName))
+		}
+		
+		liftTable := NewLiftTable(this, jsii.String("Table"), &LiftTableProps{
+			TableName:         tableName,
+			EnableMultiTenant: jsii.Bool(true),
+			EnableStreams:     jsii.Bool(true),
+			EnablePointInTimeRecovery: jsii.Bool(true),
+		})
+		table = liftTable.Table
+	}
 
 	// Create rate limit table if enabled
-	var rateLimitTable awsdynamodb.Table
+	var rateLimitTable awsdynamodb.ITable
 	if props.EnableTenantRateLimiting != nil && *props.EnableTenantRateLimiting {
-		rateLimitTable = awsdynamodb.NewTable(this, jsii.String("RateLimitTable"), &awsdynamodb.TableProps{
-			TableName:    jsii.String(fmt.Sprintf("%s-rate-limits", *props.APIName)),
-			PartitionKey: &awsdynamodb.Attribute{Name: jsii.String("tenantId"), Type: awsdynamodb.AttributeType_STRING},
-			SortKey:      &awsdynamodb.Attribute{Name: jsii.String("window"), Type: awsdynamodb.AttributeType_STRING},
-			BillingMode:  awsdynamodb.BillingMode_PAY_PER_REQUEST,
+		rateLimitTableConstruct := NewLiftTable(this, jsii.String("RateLimitTable"), &LiftTableProps{
+			TableName:           jsii.String(fmt.Sprintf("%s-rate-limits", *props.APIName)),
 			TimeToLiveAttribute: jsii.String("ttl"),
 		})
+		rateLimitTable = rateLimitTableConstruct.Table
 	}
 
 	// Create the Lambda function with multi-tenant configuration
@@ -173,8 +180,9 @@ func NewMultiTenantAPI(scope constructs.Construct, id string, props *MultiTenant
 	}
 	
 	// Add tenant-specific environment variables
-	functionEnv["TENANT_TABLE_NAME"] = tenantTable.TableName()
+	functionEnv["DYNAMODB_TABLE_NAME"] = table.TableName()
 	functionEnv["TENANT_ISOLATION_MODE"] = jsii.String(getTenantIsolationMode(props))
+	functionEnv["LIFT_MULTI_TENANT"] = jsii.String("true")
 	if props.EnableJWTTenantIsolation != nil && *props.EnableJWTTenantIsolation {
 		functionEnv["TENANT_ID_CLAIM"] = props.TenantIDClaim
 	}
@@ -203,7 +211,7 @@ func NewMultiTenantAPI(scope constructs.Construct, id string, props *MultiTenant
 	})
 
 	// Grant permissions
-	tenantTable.GrantReadWriteData(liftFunction.Function)
+	table.GrantReadWriteData(liftFunction.Function)
 	if rateLimitTable != nil {
 		rateLimitTable.GrantReadWriteData(liftFunction.Function)
 	}
@@ -385,7 +393,7 @@ func NewMultiTenantAPI(scope constructs.Construct, id string, props *MultiTenant
 		Construct:      this,
 		API:            api,
 		Function:       liftFunction,
-		TenantTable:    tenantTable,
+		Table:          table,
 		RateLimitTable: rateLimitTable,
 		WebACL:         webACL,
 	}

--- a/pkg/cdk/constructs/multi_tenant_api_test.go
+++ b/pkg/cdk/constructs/multi_tenant_api_test.go
@@ -41,7 +41,7 @@ func TestMultiTenantAPI(t *testing.T) {
 
 		assert.NotNil(t, api)
 		assert.NotNil(t, api.API)
-		assert.NotNil(t, api.TenantTable)
+		assert.NotNil(t, api.Table)
 
 		// Verify template
 		template := assertions.Template_FromStack(stack, nil)
@@ -52,12 +52,19 @@ func TestMultiTenantAPI(t *testing.T) {
 			"ProtocolType": "HTTP",
 		})
 
-		// Check tenant table exists
+		// Check table exists with standard pk/sk naming
 		template.HasResourceProperties(jsii.String("AWS::DynamoDB::Table"), map[string]interface{}{
-			"TableName": "test-api-tenants",
+			"TableName": "test-api-table",
 			"BillingMode": "PAY_PER_REQUEST",
-			"PointInTimeRecoverySpecification": map[string]interface{}{
-				"PointInTimeRecoveryEnabled": true,
+			"KeySchema": []map[string]interface{}{
+				{
+					"AttributeName": "pk",
+					"KeyType":       "HASH",
+				},
+				{
+					"AttributeName": "sk",
+					"KeyType":       "RANGE",
+				},
 			},
 		})
 	})
@@ -120,7 +127,9 @@ func TestMultiTenantAPI(t *testing.T) {
 				props := resourceMap["Properties"].(map[string]interface{})
 				if env, ok := props["Environment"].(map[string]interface{}); ok {
 					if vars, ok := env["Variables"].(map[string]interface{}); ok {
-						if vars["TENANT_ISOLATION_MODE"] == "jwt" && vars["TENANT_ID_CLAIM"] == "custom:org_id" {
+						if vars["TENANT_ISOLATION_MODE"] == "jwt" && 
+						   vars["TENANT_ID_CLAIM"] == "custom:org_id" &&
+						   vars["LIFT_MULTI_TENANT"] == "true" {
 							foundEnvVars = true
 							break
 						}
@@ -160,7 +169,9 @@ func TestMultiTenantAPI(t *testing.T) {
 				props := resourceMap["Properties"].(map[string]interface{})
 				if env, ok := props["Environment"].(map[string]interface{}); ok {
 					if vars, ok := env["Variables"].(map[string]interface{}); ok {
-						if vars["TENANT_ISOLATION_MODE"] == "header" && vars["TENANT_ID_HEADER"] == "X-Org-ID" {
+						if vars["TENANT_ISOLATION_MODE"] == "header" && 
+						   vars["TENANT_ID_HEADER"] == "X-Org-ID" &&
+						   vars["LIFT_MULTI_TENANT"] == "true" {
 							foundEnvVars = true
 							break
 						}

--- a/pkg/cdk/patterns/lift_app_test.go
+++ b/pkg/cdk/patterns/lift_app_test.go
@@ -84,11 +84,11 @@ func TestLiftApp(t *testing.T) {
 					},
 				})
 				
-				// Check tenant-aware table configuration
+				// Check tenant-aware table configuration (uses standard pk/sk naming)
 				tester.AssertHasResourceWithProperties("AWS::DynamoDB::Table", map[string]interface{}{
 					"KeySchema": []map[string]interface{}{
 						{
-							"AttributeName": "tenantId#pk",
+							"AttributeName": "pk",
 							"KeyType":       "HASH",
 						},
 						{


### PR DESCRIPTION
## Summary
- Fixes DynamoDB multi-tenant table naming to use standard `pk`/`sk` attributes instead of `tenantId#pk`
- Redesigns MultiTenantAPI construct to work with DynamORM conventions
- Resolves ValidationException when writing to multi-tenant tables with DynamORM

## Problem
When `EnableMultiTenant: true` was set in Lift CDK constructs:
1. DynamoDB tables were created with partition key named `tenantId#pk`
2. MultiTenantAPI created separate incompatible tenant tracking tables
3. DynamORM models expected standard `pk` attribute name
4. This caused: `ValidationException: Missing the key tenantId#pk in the item`

## Solution
### LiftTable/DynamoDB Construct
- Remove custom partition key naming in multi-tenant mode
- Use standard `pk`/`sk` naming that DynamORM expects
- Multi-tenant isolation achieved through key values (e.g., `tenant#123`) not attribute names

### MultiTenantAPI Construct
- Remove separate tenant tracking table with incompatible schema
- Accept existing DynamORM-compatible table or create proper LiftTable
- Use standard environment variable names (DYNAMODB_TABLE_NAME)
- Add LIFT_MULTI_TENANT=true flag

## Changes
- `pkg/cdk/constructs/dynamodb.go` - Fixed partition key naming
- `pkg/cdk/constructs/multi_tenant_api.go` - Redesigned to use DynamORM-compatible tables
- `pkg/cdk/constructs/multi_tenant_api_test.go` - Updated tests
- `pkg/cdk/patterns/lift_app_test.go` - Fixed test expectations
- `CLAUDE.md` - Added documentation for correct DynamORM multi-tenant patterns

## Test Plan
- [x] All existing tests pass
- [x] MultiTenantAPI tests updated and passing
- [ ] Deploy updated CDK construct with EnableMultiTenant: true
- [ ] Verify table created with pk/sk attributes (not tenantId#pk)
- [ ] Test DynamORM writes succeed with standard model structure
- [ ] Verify multi-tenant isolation still works through key values

## Breaking Changes
- MultiTenantAPI no longer creates a separate tenant tracking table
- MultiTenantAPI.TenantTable property renamed to Table
- Tables created with EnableMultiTenant now use `pk` instead of `tenantId#pk`

🤖 Generated with [Claude Code](https://claude.ai/code)