### PR TITLE
fix: add AWS region detection to Limited rate limit helper functions

### DIFF
--- a/pkg/middleware/limited.go
+++ b/pkg/middleware/limited.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/pay-theory/dynamorm"
@@ -127,7 +128,16 @@ func LimitedRateLimit(config LimitedConfig) (lift.Middleware, error) {
 
 // IPRateLimitWithLimited creates an IP-based rate limiter
 func IPRateLimitWithLimited(limit int, window time.Duration) (lift.Middleware, error) {
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+	}
+	if region == "" {
+		return nil, fmt.Errorf("AWS_REGION environment variable not set")
+	}
+	
 	return LimitedRateLimit(LimitedConfig{
+		Region: region,
 		Limit:  limit,
 		Window: window,
 	})
@@ -135,7 +145,16 @@ func IPRateLimitWithLimited(limit int, window time.Duration) (lift.Middleware, e
 
 // UserRateLimitWithLimited creates a user-based rate limiter
 func UserRateLimitWithLimited(limit int, window time.Duration) (lift.Middleware, error) {
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+	}
+	if region == "" {
+		return nil, fmt.Errorf("AWS_REGION environment variable not set")
+	}
+	
 	return LimitedRateLimit(LimitedConfig{
+		Region: region,
 		Limit:  limit,
 		Window: window,
 	})
@@ -143,7 +162,16 @@ func UserRateLimitWithLimited(limit int, window time.Duration) (lift.Middleware,
 
 // TenantRateLimitWithLimited creates a tenant-based rate limiter
 func TenantRateLimitWithLimited(limit int, window time.Duration) (lift.Middleware, error) {
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+	}
+	if region == "" {
+		return nil, fmt.Errorf("AWS_REGION environment variable not set")
+	}
+	
 	return LimitedRateLimit(LimitedConfig{
+		Region: region,
 		Limit:  limit,
 		Window: window,
 	})

--- a/pkg/middleware/limited_test.go
+++ b/pkg/middleware/limited_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -44,6 +45,10 @@ func TestLimitedRateLimit(t *testing.T) {
 }
 
 func TestIPRateLimitWithLimited(t *testing.T) {
+	// Set AWS_REGION for testing
+	os.Setenv("AWS_REGION", "us-east-1")
+	defer os.Unsetenv("AWS_REGION")
+	
 	middleware, err := IPRateLimitWithLimited(10, time.Minute)
 	if err != nil {
 		t.Skipf("Skipping test due to DynamoDB connection error: %v", err)
@@ -53,6 +58,10 @@ func TestIPRateLimitWithLimited(t *testing.T) {
 }
 
 func TestUserRateLimitWithLimited(t *testing.T) {
+	// Set AWS_REGION for testing
+	os.Setenv("AWS_REGION", "us-east-1")
+	defer os.Unsetenv("AWS_REGION")
+	
 	middleware, err := UserRateLimitWithLimited(100, 15*time.Minute)
 	if err != nil {
 		t.Skipf("Skipping test due to DynamoDB connection error: %v", err)
@@ -62,12 +71,37 @@ func TestUserRateLimitWithLimited(t *testing.T) {
 }
 
 func TestTenantRateLimitWithLimited(t *testing.T) {
+	// Set AWS_REGION for testing
+	os.Setenv("AWS_REGION", "us-east-1")
+	defer os.Unsetenv("AWS_REGION")
+	
 	middleware, err := TenantRateLimitWithLimited(50, 10*time.Minute)
 	if err != nil {
 		t.Skipf("Skipping test due to DynamoDB connection error: %v", err)
 	}
 	
 	assert.NotNil(t, middleware)
+}
+
+func TestRateLimitWithoutAWSRegion(t *testing.T) {
+	// Ensure AWS_REGION is not set
+	os.Unsetenv("AWS_REGION")
+	os.Unsetenv("AWS_DEFAULT_REGION")
+	
+	// Test IPRateLimitWithLimited without region
+	_, err := IPRateLimitWithLimited(10, time.Minute)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "AWS_REGION environment variable not set")
+	
+	// Test UserRateLimitWithLimited without region
+	_, err = UserRateLimitWithLimited(100, 15*time.Minute)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "AWS_REGION environment variable not set")
+	
+	// Test TenantRateLimitWithLimited without region
+	_, err = TenantRateLimitWithLimited(50, 10*time.Minute)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "AWS_REGION environment variable not set")
 }
 
 func TestLimitedConfigDefaults(t *testing.T) {


### PR DESCRIPTION
## Summary
The Limited rate limiting helper functions (`UserRateLimitWithLimited`, `IPRateLimitWithLimited`, and `TenantRateLimitWithLimited`) were failing in Lambda environments because they weren't passing the required AWS region to the underlying `LimitedRateLimit` function.

This PR fixes the issue by having these helper functions automatically detect the AWS region from environment variables.

## Changes
- Updated all three helper functions to read AWS region from `AWS_REGION` or `AWS_DEFAULT_REGION` environment variables
- Added error handling when region is not available
- Updated tests to set AWS_REGION and added new tests for the error cases

## Test plan
- [x] Existing tests pass with AWS_REGION set
- [x] New test added to verify proper error handling when AWS_REGION is not set
- [x] Manually tested the behavior to confirm the fix resolves the original issue
- [ ] Deploy to a Lambda environment and verify rate limiting works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)