### PR TITLE
fix: update CDK construct tests to use DynamORM field naming standards

### DIFF
--- a/pkg/cdk/constructs/dynamodb_test.go
+++ b/pkg/cdk/constructs/dynamodb_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestLiftTable_CreatesTableWithFieldNames(t *testing.T) {
-	// Test default behavior (pk/sk)
-	t.Run("Default pk/sk attributes", func(t *testing.T) {
+	// Test default behavior (PK/SK)
+	t.Run("Default PK/SK attributes", func(t *testing.T) {
 		app := awscdk.NewApp(nil)
 		stack := awscdk.NewStack(app, jsii.String("TestStack"), nil)
 		table := NewLiftTable(stack, jsii.String("DefaultTable"), &LiftTableProps{
 			TableName:        jsii.String("test-table"),
-			PartitionKeyName: jsii.String("pk"),
-			SortKeyName:      jsii.String("sk"),
+			PartitionKeyName: jsii.String("PK"),
+			SortKeyName:      jsii.String("SK"),
 		})
 
 		assert.NotNil(t, table)
@@ -26,25 +26,25 @@ func TestLiftTable_CreatesTableWithFieldNames(t *testing.T) {
 		// Synthesize and check CloudFormation
 		template := assertions.Template_FromStack(stack, nil)
 		
-		// Check that table has pk and sk as attribute names
+		// Check that table has PK and SK as attribute names
 		template.HasResourceProperties(jsii.String("AWS::DynamoDB::Table"), map[string]interface{}{
 			"KeySchema": []interface{}{
 				map[string]interface{}{
-					"AttributeName": "pk",
+					"AttributeName": "PK",
 					"KeyType":       "HASH",
 				},
 				map[string]interface{}{
-					"AttributeName": "sk",
+					"AttributeName": "SK",
 					"KeyType":       "RANGE",
 				},
 			},
 			"AttributeDefinitions": assertions.Match_ArrayWith(&[]interface{}{
 				map[string]interface{}{
-					"AttributeName": "pk",
+					"AttributeName": "PK",
 					"AttributeType": "S",
 				},
 				map[string]interface{}{
-					"AttributeName": "sk",
+					"AttributeName": "SK",
 					"AttributeType": "S",
 				},
 			}),

--- a/pkg/cdk/constructs/idempotent_test.go
+++ b/pkg/cdk/constructs/idempotent_test.go
@@ -40,21 +40,21 @@ func TestNewIdempotentFunction(t *testing.T) {
 					"BillingMode": "PAY_PER_REQUEST",
 					"AttributeDefinitions": assertions.Match_ArrayWith(&[]interface{}{
 						&map[string]interface{}{
-							"AttributeName": "pk",
+							"AttributeName": "PK",
 							"AttributeType": "S",
 						},
 						&map[string]interface{}{
-							"AttributeName": "sk",
+							"AttributeName": "SK",
 							"AttributeType": "S",
 						},
 					}),
 					"KeySchema": &[]interface{}{
 						&map[string]interface{}{
-							"AttributeName": "pk",
+							"AttributeName": "PK",
 							"KeyType": "HASH",
 						},
 						&map[string]interface{}{
-							"AttributeName": "sk",
+							"AttributeName": "SK",
 							"KeyType": "RANGE",
 						},
 					},

--- a/pkg/cdk/constructs/ratelimited_integration_test.go
+++ b/pkg/cdk/constructs/ratelimited_integration_test.go
@@ -80,21 +80,21 @@ func TestRateLimitedFunctionIntegration(t *testing.T) {
 		template.HasResourceProperties(jsii.String("AWS::DynamoDB::Table"), &map[string]interface{}{
 			"KeySchema": []interface{}{
 				map[string]interface{}{
-					"AttributeName": "pk",
+					"AttributeName": "PK",
 					"KeyType": "HASH",
 				},
 				map[string]interface{}{
-					"AttributeName": "sk",
+					"AttributeName": "SK",
 					"KeyType": "RANGE",
 				},
 			},
 			"AttributeDefinitions": []interface{}{
 				map[string]interface{}{
-					"AttributeName": "pk",
+					"AttributeName": "PK",
 					"AttributeType": "S",
 				},
 				map[string]interface{}{
-					"AttributeName": "sk",
+					"AttributeName": "SK",
 					"AttributeType": "S",
 				},
 			},

--- a/pkg/cdk/constructs/websocket_api_test.go
+++ b/pkg/cdk/constructs/websocket_api_test.go
@@ -39,16 +39,16 @@ func TestWebSocketAPI_DefaultConfiguration(t *testing.T) {
 		"AutoDeploy": true,
 	})
 
-	// Verify connection table is created with standard pk/sk structure
+	// Verify connection table is created with standard PK/SK structure
 	assertResourceExists(t, template, "AWS::DynamoDB::Table", map[string]interface{}{
 		"TableName": "test-websocket-api-connections",
 		"KeySchema": []interface{}{
 			map[string]interface{}{
-				"AttributeName": "pk",
+				"AttributeName": "PK",
 				"KeyType":       "HASH",
 			},
 			map[string]interface{}{
-				"AttributeName": "sk",
+				"AttributeName": "SK",
 				"KeyType":       "RANGE",
 			},
 		},


### PR DESCRIPTION
## Summary
- Fix CDK construct tests to expect uppercase PK/SK field names instead of lowercase pk/sk
- Align test expectations with DynamORM migration that standardized field naming
- All tests now pass successfully

## Files Changed
- `pkg/cdk/constructs/idempotent_test.go` - Updated idempotent function test expectations
- `pkg/cdk/constructs/ratelimited_integration_test.go` - Fixed rate limiting test field names  
- `pkg/cdk/constructs/websocket_api_test.go` - Updated WebSocket API test expectations
- `pkg/cdk/constructs/dynamodb_test.go` - Fixed DynamoDB table test to reflect current standards

## Test plan
- [x] All CDK construct tests pass
- [x] Core lift package tests pass
- [x] Middleware tests pass
- [x] Services tests pass
- [x] Testing package tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)