### PR TITLE
EMERGENCY FIX: use RemovalPolicy_DESTROY instead of non-existent RemovalPolicy_DELETE

### DIFF
--- a/pkg/cdk/constructs/lambda.go
+++ b/pkg/cdk/constructs/lambda.go
@@ -162,7 +162,7 @@ func NewLiftFunction(scope constructs.Construct, id *string, props *LiftFunction
 		logGroup = awslogs.NewLogGroup(this, jsii.String("LogGroup"), &awslogs.LogGroupProps{
 			LogGroupName:  jsii.String(logGroupName),
 			Retention:     getRetentionDays(*props.LogRetentionDays),
-			RemovalPolicy: awscdk.RemovalPolicy_DELETE, // Important: DELETE to avoid conflicts
+			RemovalPolicy: awscdk.RemovalPolicy_DESTROY, // Important: DESTROY to avoid conflicts
 		})
 		
 		// Ensure the log group is created before the function


### PR DESCRIPTION
## 🚨 EMERGENCY FIX for v1.0.48 Compilation Error

## Summary
v1.0.48 introduced a compilation error that prevents the library from being used. This PR fixes that error.

## Problem
- v1.0.48 uses `RemovalPolicy_DELETE` which doesn't exist in AWS CDK v2
- This causes a compilation error: `undefined: awscdk.RemovalPolicy_DELETE`

## Solution
- Changed to the correct value: `RemovalPolicy_DESTROY`

## Testing
- Verified the code compiles successfully with `go build ./pkg/cdk/constructs`

## Impact
This is a critical fix that needs to be released as v1.0.49 immediately to unblock users.

## Known Issues Still Present
- The double LogGroup creation bug from v1.0.47 still needs a proper fix
- This PR only addresses the compilation error to make the library usable again

🤖 Generated with [Claude Code](https://claude.ai/code)