### PR TITLE
Fix middleware response writing issue in CheckIPAuthorization

### DIFF
--- a/pkg/lift/middleware/ip_authorization.go
+++ b/pkg/lift/middleware/ip_authorization.go
@@ -52,9 +52,7 @@ func CheckIPAuthorization(ctx *lift.Context, ipAuthService *security.IPAuthoriza
 	// Check if the source IP is authorized
 	authorized, err := ipAuthService.IsAuthorizedIP(ctx.Context, sourceIP)
 	if err != nil {
-		return ctx.JSON(map[string]string{
-			"error": "Failed to check IP authorization",
-		})
+		return ctx.SystemError("Failed to check IP authorization", err)
 	}
 
 	if !authorized {


### PR DESCRIPTION
The CheckIPAuthorization middleware was calling ctx.JSON() which writes a response, but then returning nil. This caused a "Response has already been written" error when handlers tried to write their own response.

Changed to return ctx.SystemError() instead, which properly returns an error without writing a response, allowing the framework to handle the response appropriately.

🤖 Generated with [Claude Code](https://claude.ai/code)