### PR TITLE
feat: prevent key fields from being redacted in logs

### DIFF
--- a/pkg/security/dataprotection.go
+++ b/pkg/security/dataprotection.go
@@ -241,18 +241,49 @@ func (dpm *DataProtectionManager) classifyField(field string, value any) DataCla
 		return DataPublic
 	}
 
+	// Key fields should be public (not redacted) - check BEFORE other patterns
+	// Exact matches for key-related field names
+	keyExactMatches := []string{
+		"key", "keys", "apikey", "api_key", "access_key", "secret_key",
+		"encryption_key", "signing_key", "public_key", "private_key",
+		"key_id", "key_name", "key_type", "key_version", "key_arn",
+		"master_key", "data_key", "kms_key", "session_key",
+	}
+	
+	for _, keyPattern := range keyExactMatches {
+		if strings.EqualFold(fieldLower, keyPattern) {
+			// Most key fields should be DataInternal (shown but not highly restricted)
+			// except for actual secret/private keys which should be restricted
+			if strings.Contains(fieldLower, "secret") || strings.Contains(fieldLower, "private") {
+				return DataRestricted
+			}
+			return DataInternal
+		}
+	}
+	
+	// Check for key-related patterns with word boundaries
+	if fieldLower == "key" || strings.HasSuffix(fieldLower, "_key") || strings.HasPrefix(fieldLower, "key_") || 
+	   strings.HasSuffix(fieldLower, "_keys") || strings.HasPrefix(fieldLower, "keys_") {
+		// If it contains secret or private, it's restricted
+		if strings.Contains(fieldLower, "secret") || strings.Contains(fieldLower, "private") {
+			return DataRestricted
+		}
+		// Otherwise it's internal (visible but with some protections)
+		return DataInternal
+	}
+
 	// High sensitivity fields from sanitization logic
 	highSensitiveFields := []string{
 		"password", "token", "secret", "auth", "credential",
 		"email", "phone", "ssn", "card", "account", "routing",
-		"pin", "cvv", "security", "private", "confidential", "key",
+		"pin", "cvv", "security", "private", "confidential",
 	}
 
 	for _, sensitive := range highSensitiveFields {
 		if strings.Contains(fieldLower, sensitive) {
 			// Determine classification based on the type of sensitive field
 			switch sensitive {
-			case "ssn", "card", "account", "routing", "cvv", "pin", "key":
+			case "ssn", "card", "account", "routing", "cvv", "pin":
 				return DataRestricted
 			case "password", "token", "secret", "auth", "credential", "private":
 				return DataConfidential
@@ -612,8 +643,8 @@ func (dpm *DataProtectionManager) applyDefaultMasking(value any, classification 
 		return strValue[:2] + strings.Repeat("*", len(strValue)-4) + strValue[len(strValue)-2:]
 
 	case DataInternal:
-		// Internal data shows metadata only (e.g., length)
-		return fmt.Sprintf("[INTERNAL_%d_chars]", len(strValue))
+		// Internal data is not masked by default
+		return value
 
 	case DataPublic:
 		// Public data is not masked - this includes IP addresses

--- a/pkg/security/dataprotection_ip_test.go
+++ b/pkg/security/dataprotection_ip_test.go
@@ -161,7 +161,7 @@ func TestDataClassificationPriority(t *testing.T) {
 	}{
 		{"client_ip_address", DataPublic},    // Contains both "client" and "ip"
 		{"source_ip_token", DataPublic},      // Contains both "token" and "ip"
-		{"api_key", DataRestricted},          // Contains "api" and "key" but not IP pattern
+		{"api_key", DataInternal},            // Contains "api" and "key" - now classified as internal
 		{"stripe_customer_id", DataInternal}, // Contains "stripe" but not a sensitive pattern
 	}
 

--- a/pkg/security/dataprotection_test.go
+++ b/pkg/security/dataprotection_test.go
@@ -89,6 +89,29 @@ func TestDataProtectionManager_ClassifyData(t *testing.T) {
 				"name":        DataInternal,
 			},
 		},
+		{
+			name: "key fields should not be highly restricted",
+			data: map[string]any{
+				"key":         "some-key-value",
+				"api_key":     "abc123",
+				"access_key":  "AKIAIOSFODNN7EXAMPLE",
+				"secret_key":  "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				"private_key": "-----BEGIN PRIVATE KEY-----",
+				"public_key":  "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC",
+			},
+			context: map[string]any{
+				"user_id": "user123",
+			},
+			expectedClass: DataRestricted,
+			expectedFields: map[string]DataClassification{
+				"key":         DataInternal,
+				"api_key":     DataInternal,
+				"access_key":  DataInternal,
+				"secret_key":  DataRestricted,  // Contains "secret"
+				"private_key": DataRestricted,  // Contains "private"
+				"public_key":  DataInternal,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -443,6 +466,67 @@ func TestDataTokenizer(t *testing.T) {
 	// Test detokenization with invalid token
 	_, err = tokenizer.Detokenize("invalid-token")
 	assert.Error(t, err)
+}
+
+func TestDataClassification_KeyFieldPatterns(t *testing.T) {
+	config := DataProtectionConfig{
+		DefaultClassification: DataInternal,
+		EncryptionKey:         "test-key",
+	}
+
+	manager, err := NewDataProtectionManager(config)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		fieldName     string
+		value         any
+		expectedClass DataClassification
+	}{
+		// Exact matches
+		{"exact key", "key", "value", DataInternal},
+		{"exact keys", "keys", "value", DataInternal},
+		{"exact api_key", "api_key", "value", DataInternal},
+		{"exact apikey", "apikey", "value", DataInternal},
+		{"exact access_key", "access_key", "value", DataInternal},
+		{"exact secret_key", "secret_key", "value", DataRestricted}, // Contains "secret"
+		{"exact private_key", "private_key", "value", DataRestricted}, // Contains "private"
+		{"exact public_key", "public_key", "value", DataInternal},
+		
+		// Pattern matches
+		{"suffix pattern", "my_key", "value", DataInternal},
+		{"prefix pattern", "key_id", "value", DataInternal},
+		{"suffix keys pattern", "my_keys", "value", DataInternal},
+		{"prefix keys pattern", "keys_list", "value", DataInternal},
+		
+		// Should not match as key patterns
+		{"keyword in middle", "keyword", "value", DataInternal}, // Default classification
+		{"keyed value", "keyed", "value", DataInternal}, // Default classification
+		
+		// Mixed case
+		{"uppercase KEY", "KEY", "value", DataInternal},
+		{"mixed case Api_Key", "Api_Key", "value", DataInternal},
+		
+		// Secret/private key variations
+		{"aws_secret_key", "aws_secret_key", "value", DataRestricted},
+		{"private_signing_key", "private_signing_key", "value", DataRestricted},
+		{"public_signing_key", "public_signing_key", "value", DataInternal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create data context with single field
+			dataCtx := manager.ClassifyData(
+				map[string]any{tt.fieldName: tt.value},
+				map[string]any{"source": "test"},
+			)
+			
+			// Get the classification for the field
+			actualClass, exists := dataCtx.Fields[tt.fieldName]
+			assert.True(t, exists, "Field %s should be classified", tt.fieldName)
+			assert.Equal(t, tt.expectedClass, actualClass, "Field %s classification mismatch", tt.fieldName)
+		})
+	}
 }
 
 func TestDataClassification_IsRestrictedValue(t *testing.T) {

--- a/pkg/utils/sanitization/sanitization_test.go
+++ b/pkg/utils/sanitization/sanitization_test.go
@@ -93,6 +93,58 @@ func TestSanitizeFieldValue(t *testing.T) {
 			value:    "user@example.com",
 			expected: "user@example.com", // Email is classified as DataInternal by dataprotection
 		},
+		
+		// Key fields (DataInternal - should not be redacted)
+		{
+			name:     "key field",
+			key:      "key",
+			value:    "some-key-value",
+			expected: "some-key-value",
+		},
+		{
+			name:     "api_key field",
+			key:      "api_key",
+			value:    "abc123xyz",
+			expected: "abc123xyz",
+		},
+		{
+			name:     "access_key field",
+			key:      "access_key",
+			value:    "AKIAIOSFODNN7EXAMPLE",
+			expected: "AKIAIOSFODNN7EXAMPLE",
+		},
+		{
+			name:     "public_key field",
+			key:      "public_key",
+			value:    "ssh-rsa AAAAB3NzaC1yc2E",
+			expected: "ssh-rsa AAAAB3NzaC1yc2E",
+		},
+		{
+			name:     "key_id field",
+			key:      "key_id",
+			value:    "key-12345",
+			expected: "key-12345",
+		},
+		{
+			name:     "my_key suffix pattern",
+			key:      "my_key",
+			value:    "custom-key-value",
+			expected: "custom-key-value",
+		},
+		
+		// Key fields that should be redacted (contain secret/private)
+		{
+			name:     "secret_key field",
+			key:      "secret_key",
+			value:    "wJalrXUtnFEMI/K7MDENG",
+			expected: "[REDACTED]",
+		},
+		{
+			name:     "private_key field",
+			key:      "private_key",
+			value:    "-----BEGIN PRIVATE KEY-----",
+			expected: "[REDACTED]",
+		},
 		{
 			name:     "cvv field",
 			key:      "cvv",


### PR DESCRIPTION
Updated data protection logic to properly classify key-related fields as DataInternal instead of DataRestricted, ensuring they are not redacted when logging. This allows fields like "key", "api_key", "access_key" to remain visible in logs while still protecting truly sensitive fields like "secret_key" and "private_key".

- Added special handling for key field patterns before other sensitive field checks
- Key fields without "secret" or "private" are classified as DataInternal
- Fixed default masking behavior for DataInternal to not mask values
- Added comprehensive tests for key field classification and sanitization

🤖 Generated with [Claude Code](https://claude.ai/code)