### PR TITLE
fix: prevent ID fields from being redacted in logs

### DIFF
--- a/pkg/security/dataprotection.go
+++ b/pkg/security/dataprotection.go
@@ -241,6 +241,12 @@ func (dpm *DataProtectionManager) classifyField(field string, value any) DataCla
 		return DataPublic
 	}
 
+	// ID fields (anything ending with _id) should be public (not redacted)
+	// These are typically non-sensitive identifiers needed for debugging and correlation
+	if strings.HasSuffix(fieldLower, "_id") {
+		return DataPublic
+	}
+
 	// Key fields should be public (not redacted) - check BEFORE other patterns
 	// Exact matches for key-related field names
 	keyExactMatches := []string{


### PR DESCRIPTION
Fields ending with '_id' (like auth_id, transaction_id, request_id) are now classified as DataPublic to prevent unnecessary redaction. These identifiers are typically non-sensitive and needed for debugging and correlation.

🤖 Generated with [Claude Code](https://claude.ai/code)