### PR TITLE
fix: apply content-based deduplication to FIFO dead-letter queues

### DIFF
--- a/pkg/cdk/constructs/sqs_queue.go
+++ b/pkg/cdk/constructs/sqs_queue.go
@@ -152,7 +152,7 @@ func (q *LiftSQSQueue) createDeadLetterQueue(props *LiftSQSQueueProps) awssqs.Qu
 	}
 
 	applyQueueEncryption(dlqProps, props)
-	configureFifoQueue(dlqProps, props, dlqProps.QueueName, false)
+	configureFifoQueue(dlqProps, props, dlqProps.QueueName, true)
 
 	return awssqs.NewQueue(q, jsii.String("DeadLetterQueue"), dlqProps)
 }


### PR DESCRIPTION
Ensures that when a FIFO queue has content-based deduplication enabled, the dead-letter queue also inherits this configuration. This fixes a potential inconsistency where the main queue and DLQ could have mismatched FIFO settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)