### PR TITLE
fix: add austin partner to qakernel routing

### DIFF
--- a/pkg/services/kernel/client.go
+++ b/pkg/services/kernel/client.go
@@ -405,7 +405,8 @@ func (c *Client) getKernelEnvironment() string {
 		return kernelEnvOverride
 	}
 
-	if strings.EqualFold(c.partner, "innovate") {
+	// Use qakernel for innovate and austin partners
+	if strings.EqualFold(c.partner, "innovate") || strings.EqualFold(c.partner, "austin") {
 		return "qakernel"
 	}
 

--- a/pkg/services/kernel/client_test.go
+++ b/pkg/services/kernel/client_test.go
@@ -176,10 +176,10 @@ func TestGetKernelEnvironment(t *testing.T) {
 			expectedKernel: "qakernel",
 		},
 		{
-			name:           "kernel for austin partner",
+			name:           "qakernel for austin partner",
 			partner:        "austin",
 			envOverride:    "",
-			expectedKernel: "kernel",
+			expectedKernel: "qakernel",
 		},
 		{
 			name:           "kernel for paytheory partner",


### PR DESCRIPTION
Route austin partner to qakernel environment, matching the Python implementation in amaze/src/kernel/secure_api_call.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)