### PR TITLE
feat: add CloudWatch alarm constructs for SQS, API Gateway, and DynamoDB

### DIFF
--- a/pkg/cdk/constructs/alarms.go
+++ b/pkg/cdk/constructs/alarms.go
@@ -1,0 +1,552 @@
+package constructs
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-cdk-go/awscdk/v2"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awscloudwatch"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awscloudwatchactions"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awssns"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awssqs"
+	"github.com/aws/constructs-go/constructs/v10"
+	"github.com/aws/jsii-runtime-go"
+)
+
+// SQSAlarmsConfig defines configuration for SQS alarms
+type SQSAlarmsConfig struct {
+	// VisibleMessagesThreshold is the threshold for visible messages alarm
+	// Default: 2
+	VisibleMessagesThreshold *float64
+
+	// NotVisibleMessagesThreshold is the threshold for not visible messages alarm
+	// Default: 2
+	NotVisibleMessagesThreshold *float64
+
+	// OldestMessageAgeThreshold is the threshold in seconds for oldest message alarm
+	// Default: 900 (15 minutes)
+	OldestMessageAgeThreshold *float64
+
+	// DLQOldestMessageAgeThreshold is the threshold in seconds for DLQ oldest message alarm
+	// Default: 1 (alert immediately when any message hits DLQ)
+	DLQOldestMessageAgeThreshold *float64
+
+	// EvaluationPeriods is the number of periods to evaluate
+	// Default: 1
+	EvaluationPeriods *float64
+
+	// Period is the evaluation period in seconds
+	// Default: 300 (5 minutes)
+	Period *float64
+}
+
+// SQSAlarmsProps defines properties for creating SQS alarms
+type SQSAlarmsProps struct {
+	// Queue is the main SQS queue to monitor (required)
+	Queue awssqs.IQueue
+
+	// DeadLetterQueue is the DLQ to monitor (optional)
+	DeadLetterQueue awssqs.IQueue
+
+	// AlarmTopic is the SNS topic for alarm notifications (required)
+	AlarmTopic awssns.ITopic
+
+	// AlarmNamePrefix is the prefix for alarm names (required)
+	// Example: "merchant-application-partner-stage"
+	AlarmNamePrefix *string
+
+	// Config contains threshold configuration (optional - uses defaults if nil)
+	Config *SQSAlarmsConfig
+}
+
+// LiftSQSAlarms contains CloudWatch alarms for SQS queues
+type LiftSQSAlarms struct {
+	Construct constructs.Construct
+
+	// Main queue alarms
+	VisibleMessagesAlarm    awscloudwatch.Alarm
+	NotVisibleMessagesAlarm awscloudwatch.Alarm
+	OldestMessageAlarm      awscloudwatch.Alarm
+
+	// DLQ alarms
+	DLQVisibleMessagesAlarm    awscloudwatch.Alarm
+	DLQNotVisibleMessagesAlarm awscloudwatch.Alarm
+	DLQOldestMessageAlarm      awscloudwatch.Alarm
+}
+
+// NewLiftSQSAlarms creates CloudWatch alarms for SQS queues
+func NewLiftSQSAlarms(scope constructs.Construct, id *string, props *SQSAlarmsProps) *LiftSQSAlarms {
+	if props.Queue == nil {
+		panic("Queue is required")
+	}
+	if props.AlarmTopic == nil {
+		panic("AlarmTopic is required")
+	}
+	if props.AlarmNamePrefix == nil {
+		panic("AlarmNamePrefix is required")
+	}
+
+	construct := constructs.NewConstruct(scope, id)
+	this := &LiftSQSAlarms{Construct: construct}
+
+	// Apply defaults
+	config := applySQSAlarmsDefaults(props.Config)
+
+	// Create SNS action for alarms
+	snsAction := awscloudwatchactions.NewSnsAction(props.AlarmTopic)
+
+	// Create main queue alarms
+	this.VisibleMessagesAlarm = createSQSAlarm(this.Construct, &sqsAlarmInput{
+		alarmName:   fmt.Sprintf("sqs-visible-messages-%s", *props.AlarmNamePrefix),
+		description: "Alarm if there are too many visible messages in the SQS Queue",
+		metricName:  "ApproximateNumberOfMessagesVisible",
+		queueName:   props.Queue.QueueName(),
+		threshold:   config.VisibleMessagesThreshold,
+		periods:     config.EvaluationPeriods,
+		period:      config.Period,
+		snsAction:   snsAction,
+	})
+
+	this.NotVisibleMessagesAlarm = createSQSAlarm(this.Construct, &sqsAlarmInput{
+		alarmName:   fmt.Sprintf("sqs-not-visible-messages-%s", *props.AlarmNamePrefix),
+		description: "Alarm if there are too many not visible messages in the SQS Queue",
+		metricName:  "ApproximateNumberOfMessagesNotVisible",
+		queueName:   props.Queue.QueueName(),
+		threshold:   config.NotVisibleMessagesThreshold,
+		periods:     config.EvaluationPeriods,
+		period:      config.Period,
+		snsAction:   snsAction,
+	})
+
+	this.OldestMessageAlarm = createSQSAlarm(this.Construct, &sqsAlarmInput{
+		alarmName:   fmt.Sprintf("sqs-oldest-messages-%s", *props.AlarmNamePrefix),
+		description: "Alarm if messages are waiting too long in the SQS Queue",
+		metricName:  "ApproximateAgeOfOldestMessage",
+		queueName:   props.Queue.QueueName(),
+		threshold:   config.OldestMessageAgeThreshold,
+		periods:     jsii.Number(3), // 3 periods for oldest message
+		period:      config.Period,
+		statistic:   jsii.String("Maximum"),
+		snsAction:   snsAction,
+	})
+
+	// Create DLQ alarms if DLQ is provided
+	if props.DeadLetterQueue != nil {
+		dlqPrefix := fmt.Sprintf("%s-dlq", *props.AlarmNamePrefix)
+
+		this.DLQVisibleMessagesAlarm = createSQSAlarm(this.Construct, &sqsAlarmInput{
+			alarmName:   fmt.Sprintf("sqs-visible-messages-%s", dlqPrefix),
+			description: "Alarm if there are too many visible messages in the DLQ",
+			metricName:  "ApproximateNumberOfMessagesVisible",
+			queueName:   props.DeadLetterQueue.QueueName(),
+			threshold:   config.VisibleMessagesThreshold,
+			periods:     config.EvaluationPeriods,
+			period:      config.Period,
+			snsAction:   snsAction,
+		})
+
+		this.DLQNotVisibleMessagesAlarm = createSQSAlarm(this.Construct, &sqsAlarmInput{
+			alarmName:   fmt.Sprintf("sqs-not-visible-messages-%s", dlqPrefix),
+			description: "Alarm if there are too many not visible messages in the DLQ",
+			metricName:  "ApproximateNumberOfMessagesNotVisible",
+			queueName:   props.DeadLetterQueue.QueueName(),
+			threshold:   config.NotVisibleMessagesThreshold,
+			periods:     config.EvaluationPeriods,
+			period:      config.Period,
+			snsAction:   snsAction,
+		})
+
+		this.DLQOldestMessageAlarm = createSQSAlarm(this.Construct, &sqsAlarmInput{
+			alarmName:   fmt.Sprintf("sqs-oldest-messages-%s", dlqPrefix),
+			description: "Alarm for messages in DLQ exceeding age threshold",
+			metricName:  "ApproximateAgeOfOldestMessage",
+			queueName:   props.DeadLetterQueue.QueueName(),
+			threshold:   config.DLQOldestMessageAgeThreshold,
+			periods:     jsii.Number(1), // Alert immediately for DLQ
+			period:      jsii.Number(60),
+			statistic:   jsii.String("Maximum"),
+			snsAction:   snsAction,
+		})
+	}
+
+	return this
+}
+
+type sqsAlarmInput struct {
+	alarmName   string
+	description string
+	metricName  string
+	queueName   *string
+	threshold   *float64
+	periods     *float64
+	period      *float64
+	statistic   *string
+	snsAction   awscloudwatch.IAlarmAction
+}
+
+func createSQSAlarm(scope constructs.Construct, input *sqsAlarmInput) awscloudwatch.Alarm {
+	statistic := input.statistic
+	if statistic == nil {
+		statistic = jsii.String("Sum")
+	}
+
+	metric := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+		Namespace:  jsii.String("AWS/SQS"),
+		MetricName: jsii.String(input.metricName),
+		DimensionsMap: &map[string]*string{
+			"QueueName": input.queueName,
+		},
+		Statistic: statistic,
+		Period:    awscdk.Duration_Seconds(input.period),
+	})
+
+	alarm := awscloudwatch.NewAlarm(scope, jsii.String(input.alarmName), &awscloudwatch.AlarmProps{
+		AlarmName:          jsii.String(input.alarmName),
+		AlarmDescription:   jsii.String(input.description),
+		Metric:             metric,
+		Threshold:          input.threshold,
+		EvaluationPeriods:  input.periods,
+		ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+	})
+
+	alarm.AddAlarmAction(input.snsAction)
+
+	return alarm
+}
+
+func applySQSAlarmsDefaults(config *SQSAlarmsConfig) *SQSAlarmsConfig {
+	if config == nil {
+		config = &SQSAlarmsConfig{}
+	}
+
+	if config.VisibleMessagesThreshold == nil {
+		config.VisibleMessagesThreshold = jsii.Number(2)
+	}
+	if config.NotVisibleMessagesThreshold == nil {
+		config.NotVisibleMessagesThreshold = jsii.Number(2)
+	}
+	if config.OldestMessageAgeThreshold == nil {
+		config.OldestMessageAgeThreshold = jsii.Number(900) // 15 minutes
+	}
+	if config.DLQOldestMessageAgeThreshold == nil {
+		config.DLQOldestMessageAgeThreshold = jsii.Number(1) // Alert immediately
+	}
+	if config.EvaluationPeriods == nil {
+		config.EvaluationPeriods = jsii.Number(1)
+	}
+	if config.Period == nil {
+		config.Period = jsii.Number(300) // 5 minutes
+	}
+
+	return config
+}
+
+// APIGatewayAlarmsConfig defines configuration for API Gateway alarms
+type APIGatewayAlarmsConfig struct {
+	// ClientErrorThreshold is the threshold for 4xx errors
+	// Default: 10
+	ClientErrorThreshold *float64
+
+	// ServerErrorThreshold is the threshold for 5xx errors
+	// Default: 5
+	ServerErrorThreshold *float64
+
+	// EvaluationPeriods is the number of periods to evaluate
+	// Default: 3
+	EvaluationPeriods *float64
+
+	// Period is the evaluation period in seconds
+	// Default: 300 (5 minutes)
+	Period *float64
+}
+
+// APIGatewayAlarmsProps defines properties for creating API Gateway alarms
+type APIGatewayAlarmsProps struct {
+	// ApiId is the API Gateway ID (required)
+	ApiId *string
+
+	// StageName is the API Gateway stage name
+	// Default: "latest"
+	StageName *string
+
+	// AlarmTopic is the SNS topic for alarm notifications (required)
+	AlarmTopic awssns.ITopic
+
+	// AlarmNamePrefix is the prefix for alarm names (required)
+	// Example: "merchant-application-partner-stage"
+	AlarmNamePrefix *string
+
+	// Config contains threshold configuration (optional - uses defaults if nil)
+	Config *APIGatewayAlarmsConfig
+}
+
+// LiftAPIGatewayAlarms contains CloudWatch alarms for API Gateway
+type LiftAPIGatewayAlarms struct {
+	Construct constructs.Construct
+
+	ClientErrorsAlarm awscloudwatch.Alarm
+	ServerErrorsAlarm awscloudwatch.Alarm
+}
+
+// NewLiftAPIGatewayAlarms creates CloudWatch alarms for API Gateway
+func NewLiftAPIGatewayAlarms(scope constructs.Construct, id *string, props *APIGatewayAlarmsProps) *LiftAPIGatewayAlarms {
+	if props.ApiId == nil {
+		panic("ApiId is required")
+	}
+	if props.AlarmTopic == nil {
+		panic("AlarmTopic is required")
+	}
+	if props.AlarmNamePrefix == nil {
+		panic("AlarmNamePrefix is required")
+	}
+
+	construct := constructs.NewConstruct(scope, id)
+	this := &LiftAPIGatewayAlarms{Construct: construct}
+
+	// Apply defaults
+	config := applyAPIGatewayAlarmsDefaults(props.Config)
+	stageName := props.StageName
+	if stageName == nil {
+		stageName = jsii.String("latest")
+	}
+
+	// Create SNS action for alarms
+	snsAction := awscloudwatchactions.NewSnsAction(props.AlarmTopic)
+
+	// Create 4xx client errors alarm
+	clientErrorMetric := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+		Namespace:  jsii.String("AWS/ApiGateway"),
+		MetricName: jsii.String("4xx"),
+		DimensionsMap: &map[string]*string{
+			"ApiId": props.ApiId,
+			"Stage": stageName,
+		},
+		Statistic: jsii.String("Sum"),
+		Period:    awscdk.Duration_Seconds(config.Period),
+	})
+
+	clientAlarmName := fmt.Sprintf("api-gateway-client-errors-%s", *props.AlarmNamePrefix)
+	this.ClientErrorsAlarm = awscloudwatch.NewAlarm(this.Construct, jsii.String("ClientErrorsAlarm"), &awscloudwatch.AlarmProps{
+		AlarmName:          jsii.String(clientAlarmName),
+		AlarmDescription:   jsii.String("Alarm if API Gateway client errors hit threshold"),
+		Metric:             clientErrorMetric,
+		Threshold:          config.ClientErrorThreshold,
+		EvaluationPeriods:  config.EvaluationPeriods,
+		ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+	})
+	this.ClientErrorsAlarm.AddAlarmAction(snsAction)
+
+	// Create 5xx server errors alarm
+	serverErrorMetric := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+		Namespace:  jsii.String("AWS/ApiGateway"),
+		MetricName: jsii.String("5xx"),
+		DimensionsMap: &map[string]*string{
+			"ApiId": props.ApiId,
+			"Stage": stageName,
+		},
+		Statistic: jsii.String("Sum"),
+		Period:    awscdk.Duration_Seconds(config.Period),
+	})
+
+	serverAlarmName := fmt.Sprintf("api-gateway-server-errors-%s", *props.AlarmNamePrefix)
+	this.ServerErrorsAlarm = awscloudwatch.NewAlarm(this.Construct, jsii.String("ServerErrorsAlarm"), &awscloudwatch.AlarmProps{
+		AlarmName:          jsii.String(serverAlarmName),
+		AlarmDescription:   jsii.String("Alarm if API Gateway server errors hit threshold"),
+		Metric:             serverErrorMetric,
+		Threshold:          config.ServerErrorThreshold,
+		EvaluationPeriods:  config.EvaluationPeriods,
+		ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+	})
+	this.ServerErrorsAlarm.AddAlarmAction(snsAction)
+
+	return this
+}
+
+func applyAPIGatewayAlarmsDefaults(config *APIGatewayAlarmsConfig) *APIGatewayAlarmsConfig {
+	if config == nil {
+		config = &APIGatewayAlarmsConfig{}
+	}
+
+	if config.ClientErrorThreshold == nil {
+		config.ClientErrorThreshold = jsii.Number(10)
+	}
+	if config.ServerErrorThreshold == nil {
+		config.ServerErrorThreshold = jsii.Number(5)
+	}
+	if config.EvaluationPeriods == nil {
+		config.EvaluationPeriods = jsii.Number(3)
+	}
+	if config.Period == nil {
+		config.Period = jsii.Number(300) // 5 minutes
+	}
+
+	return config
+}
+
+// DynamoDBAlarmsConfig defines configuration for DynamoDB alarms
+type DynamoDBAlarmsConfig struct {
+	// LatencyThreshold is the threshold in milliseconds for latency alarm
+	// Default: 250
+	LatencyThreshold *float64
+
+	// ReadCapacityThreshold is the threshold for consumed read capacity units
+	// Default: 900
+	ReadCapacityThreshold *float64
+
+	// WriteCapacityThreshold is the threshold for consumed write capacity units
+	// Default: 900
+	WriteCapacityThreshold *float64
+
+	// EvaluationPeriods is the number of periods to evaluate
+	// Default: 3
+	EvaluationPeriods *float64
+
+	// Period is the evaluation period in seconds
+	// Default: 300 (5 minutes)
+	Period *float64
+}
+
+// DynamoDBAlarmsProps defines properties for creating DynamoDB alarms
+type DynamoDBAlarmsProps struct {
+	// TableName is the DynamoDB table name (required)
+	TableName *string
+
+	// AlarmTopic is the SNS topic for alarm notifications (required)
+	AlarmTopic awssns.ITopic
+
+	// AlarmNamePrefix is the prefix for alarm names (required)
+	// Example: "merchant-application-partner-stage"
+	AlarmNamePrefix *string
+
+	// Config contains threshold configuration (optional - uses defaults if nil)
+	Config *DynamoDBAlarmsConfig
+}
+
+// LiftDynamoDBAlarms contains CloudWatch alarms for DynamoDB
+type LiftDynamoDBAlarms struct {
+	Construct constructs.Construct
+
+	LatencyAlarm       awscloudwatch.Alarm
+	ReadCapacityAlarm  awscloudwatch.Alarm
+	WriteCapacityAlarm awscloudwatch.Alarm
+}
+
+// NewLiftDynamoDBAlarms creates CloudWatch alarms for DynamoDB tables
+func NewLiftDynamoDBAlarms(scope constructs.Construct, id *string, props *DynamoDBAlarmsProps) *LiftDynamoDBAlarms {
+	if props.TableName == nil {
+		panic("TableName is required")
+	}
+	if props.AlarmTopic == nil {
+		panic("AlarmTopic is required")
+	}
+	if props.AlarmNamePrefix == nil {
+		panic("AlarmNamePrefix is required")
+	}
+
+	construct := constructs.NewConstruct(scope, id)
+	this := &LiftDynamoDBAlarms{Construct: construct}
+
+	// Apply defaults
+	config := applyDynamoDBAlarmsDefaults(props.Config)
+
+	// Create SNS action for alarms
+	snsAction := awscloudwatchactions.NewSnsAction(props.AlarmTopic)
+
+	// Create latency alarm
+	latencyMetric := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+		Namespace:  jsii.String("AWS/DynamoDB"),
+		MetricName: jsii.String("SuccessfulRequestLatency"),
+		DimensionsMap: &map[string]*string{
+			"TableName": props.TableName,
+			"Operation": jsii.String("PutItem"),
+		},
+		Statistic: jsii.String("Average"),
+		Period:    awscdk.Duration_Seconds(config.Period),
+	})
+
+	latencyAlarmName := fmt.Sprintf("dynamodb-latency-%s", *props.AlarmNamePrefix)
+	this.LatencyAlarm = awscloudwatch.NewAlarm(this.Construct, jsii.String("LatencyAlarm"), &awscloudwatch.AlarmProps{
+		AlarmName:          jsii.String(latencyAlarmName),
+		AlarmDescription:   jsii.String("Alarm if DynamoDB latency hits threshold"),
+		Metric:             latencyMetric,
+		Threshold:          config.LatencyThreshold,
+		EvaluationPeriods:  config.EvaluationPeriods,
+		ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+	})
+	this.LatencyAlarm.AddAlarmAction(snsAction)
+
+	// Create read capacity alarm
+	readCapacityMetric := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+		Namespace:  jsii.String("AWS/DynamoDB"),
+		MetricName: jsii.String("ConsumedReadCapacityUnits"),
+		DimensionsMap: &map[string]*string{
+			"TableName": props.TableName,
+		},
+		Statistic: jsii.String("Sum"),
+		Period:    awscdk.Duration_Seconds(config.Period),
+	})
+
+	readAlarmName := fmt.Sprintf("dynamodb-read-capacity-%s", *props.AlarmNamePrefix)
+	this.ReadCapacityAlarm = awscloudwatch.NewAlarm(this.Construct, jsii.String("ReadCapacityAlarm"), &awscloudwatch.AlarmProps{
+		AlarmName:          jsii.String(readAlarmName),
+		AlarmDescription:   jsii.String("Alarm if DynamoDB table read capacity exceeds threshold"),
+		Metric:             readCapacityMetric,
+		Threshold:          config.ReadCapacityThreshold,
+		EvaluationPeriods:  config.EvaluationPeriods,
+		ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+	})
+	this.ReadCapacityAlarm.AddAlarmAction(snsAction)
+
+	// Create write capacity alarm
+	writeCapacityMetric := awscloudwatch.NewMetric(&awscloudwatch.MetricProps{
+		Namespace:  jsii.String("AWS/DynamoDB"),
+		MetricName: jsii.String("ConsumedWriteCapacityUnits"),
+		DimensionsMap: &map[string]*string{
+			"TableName": props.TableName,
+		},
+		Statistic: jsii.String("Sum"),
+		Period:    awscdk.Duration_Seconds(config.Period),
+	})
+
+	writeAlarmName := fmt.Sprintf("dynamodb-write-capacity-%s", *props.AlarmNamePrefix)
+	this.WriteCapacityAlarm = awscloudwatch.NewAlarm(this.Construct, jsii.String("WriteCapacityAlarm"), &awscloudwatch.AlarmProps{
+		AlarmName:          jsii.String(writeAlarmName),
+		AlarmDescription:   jsii.String("Alarm if DynamoDB table write capacity exceeds threshold"),
+		Metric:             writeCapacityMetric,
+		Threshold:          config.WriteCapacityThreshold,
+		EvaluationPeriods:  config.EvaluationPeriods,
+		ComparisonOperator: awscloudwatch.ComparisonOperator_GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+		TreatMissingData:   awscloudwatch.TreatMissingData_NOT_BREACHING,
+	})
+	this.WriteCapacityAlarm.AddAlarmAction(snsAction)
+
+	return this
+}
+
+func applyDynamoDBAlarmsDefaults(config *DynamoDBAlarmsConfig) *DynamoDBAlarmsConfig {
+	if config == nil {
+		config = &DynamoDBAlarmsConfig{}
+	}
+
+	if config.LatencyThreshold == nil {
+		config.LatencyThreshold = jsii.Number(250) // 250ms
+	}
+	if config.ReadCapacityThreshold == nil {
+		config.ReadCapacityThreshold = jsii.Number(900)
+	}
+	if config.WriteCapacityThreshold == nil {
+		config.WriteCapacityThreshold = jsii.Number(900)
+	}
+	if config.EvaluationPeriods == nil {
+		config.EvaluationPeriods = jsii.Number(3)
+	}
+	if config.Period == nil {
+		config.Period = jsii.Number(300) // 5 minutes
+	}
+
+	return config
+}

--- a/pkg/cdk/constructs/alarms_test.go
+++ b/pkg/cdk/constructs/alarms_test.go
@@ -1,0 +1,249 @@
+package constructs
+
+import (
+	"testing"
+
+	"github.com/aws/aws-cdk-go/awscdk/v2"
+	"github.com/aws/aws-cdk-go/awscdk/v2/assertions"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awssns"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awssqs"
+	"github.com/aws/jsii-runtime-go"
+)
+
+func TestNewLiftSQSAlarms(t *testing.T) {
+	app := awscdk.NewApp(nil)
+	stack := awscdk.NewStack(app, jsii.String("TestStack"), nil)
+
+	// Create test queue
+	queue := awssqs.NewQueue(stack, jsii.String("TestQueue"), &awssqs.QueueProps{
+		QueueName: jsii.String("test-queue"),
+	})
+
+	// Create test DLQ
+	dlq := awssqs.NewQueue(stack, jsii.String("TestDLQ"), &awssqs.QueueProps{
+		QueueName: jsii.String("test-dlq"),
+	})
+
+	// Create test SNS topic
+	topic := awssns.NewTopic(stack, jsii.String("TestTopic"), &awssns.TopicProps{
+		TopicName: jsii.String("test-topic"),
+	})
+
+	// Create SQS alarms
+	alarms := NewLiftSQSAlarms(stack, jsii.String("TestSQSAlarms"), &SQSAlarmsProps{
+		Queue:           queue,
+		DeadLetterQueue: dlq,
+		AlarmTopic:      topic,
+		AlarmNamePrefix: jsii.String("test-service-partner-stage"),
+	})
+
+	// Verify alarms were created
+	if alarms.VisibleMessagesAlarm == nil {
+		t.Error("VisibleMessagesAlarm should not be nil")
+	}
+	if alarms.NotVisibleMessagesAlarm == nil {
+		t.Error("NotVisibleMessagesAlarm should not be nil")
+	}
+	if alarms.OldestMessageAlarm == nil {
+		t.Error("OldestMessageAlarm should not be nil")
+	}
+	if alarms.DLQVisibleMessagesAlarm == nil {
+		t.Error("DLQVisibleMessagesAlarm should not be nil")
+	}
+	if alarms.DLQNotVisibleMessagesAlarm == nil {
+		t.Error("DLQNotVisibleMessagesAlarm should not be nil")
+	}
+	if alarms.DLQOldestMessageAlarm == nil {
+		t.Error("DLQOldestMessageAlarm should not be nil")
+	}
+
+	// Verify CloudFormation template
+	template := assertions.Template_FromStack(stack, nil)
+
+	// Check that 6 alarms were created (3 for main queue, 3 for DLQ)
+	template.ResourceCountIs(jsii.String("AWS::CloudWatch::Alarm"), jsii.Number(6))
+}
+
+func TestNewLiftSQSAlarmsWithoutDLQ(t *testing.T) {
+	app := awscdk.NewApp(nil)
+	stack := awscdk.NewStack(app, jsii.String("TestStack"), nil)
+
+	// Create test queue
+	queue := awssqs.NewQueue(stack, jsii.String("TestQueue"), &awssqs.QueueProps{
+		QueueName: jsii.String("test-queue"),
+	})
+
+	// Create test SNS topic
+	topic := awssns.NewTopic(stack, jsii.String("TestTopic"), &awssns.TopicProps{
+		TopicName: jsii.String("test-topic"),
+	})
+
+	// Create SQS alarms without DLQ
+	alarms := NewLiftSQSAlarms(stack, jsii.String("TestSQSAlarms"), &SQSAlarmsProps{
+		Queue:           queue,
+		AlarmTopic:      topic,
+		AlarmNamePrefix: jsii.String("test-service-partner-stage"),
+	})
+
+	// Verify main queue alarms were created
+	if alarms.VisibleMessagesAlarm == nil {
+		t.Error("VisibleMessagesAlarm should not be nil")
+	}
+
+	// Verify DLQ alarms are nil
+	if alarms.DLQVisibleMessagesAlarm != nil {
+		t.Error("DLQVisibleMessagesAlarm should be nil when no DLQ provided")
+	}
+
+	// Verify CloudFormation template
+	template := assertions.Template_FromStack(stack, nil)
+
+	// Check that only 3 alarms were created (main queue only)
+	template.ResourceCountIs(jsii.String("AWS::CloudWatch::Alarm"), jsii.Number(3))
+}
+
+func TestNewLiftSQSAlarmsWithCustomConfig(t *testing.T) {
+	app := awscdk.NewApp(nil)
+	stack := awscdk.NewStack(app, jsii.String("TestStack"), nil)
+
+	// Create test queue
+	queue := awssqs.NewQueue(stack, jsii.String("TestQueue"), &awssqs.QueueProps{
+		QueueName: jsii.String("test-queue"),
+	})
+
+	// Create test SNS topic
+	topic := awssns.NewTopic(stack, jsii.String("TestTopic"), &awssns.TopicProps{
+		TopicName: jsii.String("test-topic"),
+	})
+
+	// Create SQS alarms with custom config
+	NewLiftSQSAlarms(stack, jsii.String("TestSQSAlarms"), &SQSAlarmsProps{
+		Queue:           queue,
+		AlarmTopic:      topic,
+		AlarmNamePrefix: jsii.String("test-service"),
+		Config: &SQSAlarmsConfig{
+			VisibleMessagesThreshold: jsii.Number(5),
+			OldestMessageAgeThreshold: jsii.Number(600),
+		},
+	})
+
+	// Verify CloudFormation template has custom threshold
+	template := assertions.Template_FromStack(stack, nil)
+	template.HasResourceProperties(jsii.String("AWS::CloudWatch::Alarm"), map[string]any{
+		"AlarmName": "sqs-visible-messages-test-service",
+		"Threshold": 5,
+	})
+}
+
+func TestNewLiftAPIGatewayAlarms(t *testing.T) {
+	app := awscdk.NewApp(nil)
+	stack := awscdk.NewStack(app, jsii.String("TestStack"), nil)
+
+	// Create test SNS topic
+	topic := awssns.NewTopic(stack, jsii.String("TestTopic"), &awssns.TopicProps{
+		TopicName: jsii.String("test-topic"),
+	})
+
+	// Create API Gateway alarms
+	alarms := NewLiftAPIGatewayAlarms(stack, jsii.String("TestAPIAlarms"), &APIGatewayAlarmsProps{
+		ApiId:           jsii.String("test-api-id"),
+		AlarmTopic:      topic,
+		AlarmNamePrefix: jsii.String("test-service-partner-stage"),
+	})
+
+	// Verify alarms were created
+	if alarms.ClientErrorsAlarm == nil {
+		t.Error("ClientErrorsAlarm should not be nil")
+	}
+	if alarms.ServerErrorsAlarm == nil {
+		t.Error("ServerErrorsAlarm should not be nil")
+	}
+
+	// Verify CloudFormation template
+	template := assertions.Template_FromStack(stack, nil)
+
+	// Check that 2 alarms were created
+	template.ResourceCountIs(jsii.String("AWS::CloudWatch::Alarm"), jsii.Number(2))
+
+	// Check 4xx alarm properties
+	template.HasResourceProperties(jsii.String("AWS::CloudWatch::Alarm"), map[string]any{
+		"AlarmName": "api-gateway-client-errors-test-service-partner-stage",
+		"Threshold": 10,
+	})
+
+	// Check 5xx alarm properties
+	template.HasResourceProperties(jsii.String("AWS::CloudWatch::Alarm"), map[string]any{
+		"AlarmName": "api-gateway-server-errors-test-service-partner-stage",
+		"Threshold": 5,
+	})
+}
+
+func TestNewLiftDynamoDBAlarms(t *testing.T) {
+	app := awscdk.NewApp(nil)
+	stack := awscdk.NewStack(app, jsii.String("TestStack"), nil)
+
+	// Create test SNS topic
+	topic := awssns.NewTopic(stack, jsii.String("TestTopic"), &awssns.TopicProps{
+		TopicName: jsii.String("test-topic"),
+	})
+
+	// Create DynamoDB alarms
+	alarms := NewLiftDynamoDBAlarms(stack, jsii.String("TestDDBAlarms"), &DynamoDBAlarmsProps{
+		TableName:       jsii.String("test-table"),
+		AlarmTopic:      topic,
+		AlarmNamePrefix: jsii.String("test-service-partner-stage"),
+	})
+
+	// Verify alarms were created
+	if alarms.LatencyAlarm == nil {
+		t.Error("LatencyAlarm should not be nil")
+	}
+	if alarms.ReadCapacityAlarm == nil {
+		t.Error("ReadCapacityAlarm should not be nil")
+	}
+	if alarms.WriteCapacityAlarm == nil {
+		t.Error("WriteCapacityAlarm should not be nil")
+	}
+
+	// Verify CloudFormation template
+	template := assertions.Template_FromStack(stack, nil)
+
+	// Check that 3 alarms were created
+	template.ResourceCountIs(jsii.String("AWS::CloudWatch::Alarm"), jsii.Number(3))
+
+	// Check latency alarm properties
+	template.HasResourceProperties(jsii.String("AWS::CloudWatch::Alarm"), map[string]any{
+		"AlarmName": "dynamodb-latency-test-service-partner-stage",
+		"Threshold": 250,
+	})
+
+	// Check read capacity alarm properties
+	template.HasResourceProperties(jsii.String("AWS::CloudWatch::Alarm"), map[string]any{
+		"AlarmName": "dynamodb-read-capacity-test-service-partner-stage",
+		"Threshold": 900,
+	})
+
+	// Check write capacity alarm properties
+	template.HasResourceProperties(jsii.String("AWS::CloudWatch::Alarm"), map[string]any{
+		"AlarmName": "dynamodb-write-capacity-test-service-partner-stage",
+		"Threshold": 900,
+	})
+}
+
+func TestNewLiftDynamoDBAlarmsPanicsWithoutTableName(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic when TableName is nil")
+		}
+	}()
+
+	app := awscdk.NewApp(nil)
+	stack := awscdk.NewStack(app, jsii.String("TestStack"), nil)
+
+	topic := awssns.NewTopic(stack, jsii.String("TestTopic"), nil)
+
+	NewLiftDynamoDBAlarms(stack, jsii.String("TestDDBAlarms"), &DynamoDBAlarmsProps{
+		AlarmTopic:      topic,
+		AlarmNamePrefix: jsii.String("test"),
+	})
+}


### PR DESCRIPTION
Add reusable Lift CDK constructs for creating CloudWatch alarms:

- LiftSQSAlarms: Creates alarms for visible messages, not visible messages, and oldest message age for both main queue and DLQ
- LiftAPIGatewayAlarms: Creates alarms for 4xx client errors and 5xx server errors
- LiftDynamoDBAlarms: Creates alarms for latency, read capacity, and write capacity

All constructs accept configurable thresholds and SNS topic for notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)