### PR TITLE
feat: Add per-method streaming overrides to `LiftRestAPI` integration…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- **CDK (LiftRestAPI)**: Per-method response streaming overrides via `IntegrationOptions.EnableStreaming` and `IntegrationOptions.StreamingTimeoutSeconds`, enabling mixed buffered + streaming methods on the same REST API.
+
+### Changed
+- **Runtime (SSE)**: `lift.SSEResponse` returns `events.APIGatewayProxyStreamingResponse` for API Gateway REST API (v1) triggers (keeps `events.LambdaFunctionURLStreamingResponse` for other trigger types).
+- **Dependencies**: Updated `github.com/aws/aws-lambda-go` to include `events.APIGatewayProxyStreamingResponse`.
+- **Docs**: Clarified per-method streaming configuration (`ResponseTransferMode=STREAM` + `/response-streaming-invocations`) and documented key platform limits (15m integration timeout, idle timeouts).
+
 ## v1.0.80 - 2025-12-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v1.0.81 - 2025-12-21
 
 ### Added
 - **CDK (LiftRestAPI)**: Per-method response streaming overrides via `IntegrationOptions.EnableStreaming` and `IntegrationOptions.StreamingTimeoutSeconds`, enabling mixed buffered + streaming methods on the same REST API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - **Runtime (SSE)**: `lift.SSEResponse` returns `events.APIGatewayProxyStreamingResponse` for API Gateway REST API (v1) triggers (keeps `events.LambdaFunctionURLStreamingResponse` for other trigger types).
+- **Runtime (SSE)**: Added `ctx.AddMultiValueHeader(...)` support for API Gateway REST API (v1) streaming responses (`multiValueHeaders` metadata).
 - **Dependencies**: Updated `github.com/aws/aws-lambda-go` to include `events.APIGatewayProxyStreamingResponse`.
 - **Docs**: Clarified per-method streaming configuration (`ResponseTransferMode=STREAM` + `/response-streaming-invocations`) and documented key platform limits (15m integration timeout, idle timeouts).
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -648,8 +648,10 @@ log.Println("Processing") // ❌ No context
 
 **Purpose:** Stream Server-Sent Events (SSE) to the client over a single HTTP response  
 **When to use:** Progress updates, live feeds, one-way server → client notifications  
-**Requires:** Lambda response streaming build (`-tags lambda.norpc`) and an integration that supports streaming (API Gateway REST API v1 with `ResponseTransferMode: STREAM`)  
+**Requires:** Lambda response streaming build (`-tags lambda.norpc`) and an integration that supports streaming (API Gateway REST API v1 with `ResponseTransferMode: STREAM` + `/response-streaming-invocations`)  
 **When NOT to use:** Bidirectional messaging (use WebSockets) or background work that must outlive the request
+
+**Return type:** API Gateway REST API (v1) triggers return `events.APIGatewayProxyStreamingResponse`; other triggers return `events.LambdaFunctionURLStreamingResponse`.
 
 ```go
 // CORRECT: Configure an SSE streaming response and return from the handler.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -653,6 +653,8 @@ log.Println("Processing") // ❌ No context
 
 **Return type:** API Gateway REST API (v1) triggers return `events.APIGatewayProxyStreamingResponse`; other triggers return `events.LambdaFunctionURLStreamingResponse`.
 
+**Multi-value headers (APIGW v1 streaming only):** call `ctx.AddMultiValueHeader("Header-Name", "value")` before returning `lift.SSEResponse(...)` to populate `multiValueHeaders` in the streaming response metadata.
+
 ```go
 // CORRECT: Configure an SSE streaming response and return from the handler.
 func Events(ctx *lift.Context) error {

--- a/docs/cdk-api-reference.md
+++ b/docs/cdk-api-reference.md
@@ -200,8 +200,8 @@ func NewLiftRestAPI(scope constructs.Construct, id *string, props *LiftRestAPIPr
 | `APICommonProps.DomainName` | `*string` | `nil` | Custom domain |
 | `APICommonProps.CertificateArn` | `*string` | `nil` | ACM certificate ARN (domain) |
 | `Certificate` | `awscertificatemanager.ICertificate` | `nil` | Certificate object (domain) |
-| `EnableStreaming` | `*bool` | `false` | Enable REST API response streaming integrations |
-| `StreamingTimeout` | `*int` | `900` (when streaming enabled) | Integration timeout in seconds (max 900) |
+| `EnableStreaming` | `*bool` | `false` | Enable response streaming integrations by default (overridable per method) |
+| `StreamingTimeout` | `*int` | `900` | Default streaming integration timeout in seconds (max 900) |
 | `EndpointType` | `awsapigateway.EndpointType` | `REGIONAL` | Endpoint type |
 | `DefaultAuthorizer` | `awsapigateway.IAuthorizer` | `nil` | Default authorizer |
 
@@ -210,14 +210,19 @@ func NewLiftRestAPI(scope constructs.Construct, id *string, props *LiftRestAPIPr
 | Method | Description |
 |--------|-------------|
 | `AddLambdaIntegration(path, method, fn)` | Adds a Lambda proxy integration |
-| `AddLambdaIntegrationWithOptions(path, method, fn, options)` | Adds integration with authorizer/validator/api-key settings |
+| `AddLambdaIntegrationWithOptions(path, method, fn, options)` | Adds integration with authorizer/validator/api-key + per-method streaming overrides |
 
 #### Streaming Behavior
 
-When `EnableStreaming` is true:
+Streaming can be enabled per method:
+- Default behavior comes from `LiftRestAPIProps.EnableStreaming`
+- Override per method via `IntegrationOptions.EnableStreaming`
+- Set default timeout via `LiftRestAPIProps.StreamingTimeout` and override per method via `IntegrationOptions.StreamingTimeoutSeconds`
+
+When streaming is enabled for a method:
 - The method integration is configured with `ResponseTransferMode: STREAM`
 - Lift sets the streaming invocation URI: `.../2021-11-15/functions/{arn}/response-streaming-invocations`
-- Lift can extend the integration timeout up to 15 minutes (900 seconds)
+- Lift overrides `TimeoutInMillis` (max 900 seconds)
 
 #### Example: SSE endpoint behind REST API v1
 

--- a/docs/core-patterns.md
+++ b/docs/core-patterns.md
@@ -251,7 +251,7 @@ func tenantMiddleware() lift.Middleware {
 
 **IMPORTANT**: SSE streaming requires two things:
 1. **Lambda response streaming build**: compile with `-tags lambda.norpc`
-2. **REST API v1 streaming integration**: deploy behind API Gateway REST API (v1) with `ResponseTransferMode: STREAM` (use `LiftRestAPI` with `EnableStreaming`)
+2. **REST API v1 streaming integration**: deploy behind API Gateway REST API (v1) with `ResponseTransferMode: STREAM` (use `LiftRestAPI` with `EnableStreaming` or enable per-method via `IntegrationOptions.EnableStreaming`)
 
 #### Step 1: Implement an SSE handler
 
@@ -286,6 +286,8 @@ api := liftconstructs.NewLiftRestAPI(stack, jsii.String("RestAPI"), &liftconstru
 
 api.AddLambdaIntegration(jsii.String("/events"), jsii.String("GET"), fn)
 ```
+
+If you only want to stream specific endpoints, keep `EnableStreaming` off and enable streaming per method using `AddLambdaIntegrationWithOptions` + `IntegrationOptions.EnableStreaming`.
 
 #### Step 3: Build for Lambda response streaming
 

--- a/docs/response-streaming.md
+++ b/docs/response-streaming.md
@@ -82,6 +82,7 @@ func main() {
 - Sets `Content-Type: text/event-stream`
 - Formats each `SSEEvent` into SSE wire format (`event:`, `id:`, `retry:`, `data:`)
 - Returns an AWS Lambda streaming response type so the runtime can stream bytes to the client
+- For API Gateway REST API (v1), supports `multiValueHeaders` response metadata via `ctx.AddMultiValueHeader(...)`
 
 ### Client: Minimal browser example
 
@@ -187,7 +188,18 @@ api := constructs.NewLiftAPI(stack, jsii.String("HttpAPI"), &constructs.LiftAPIP
 API Gateway response streaming has important platform behaviors:
 - **Integration timeout**: up to **15 minutes** (900 seconds) for streaming-enabled methods.
 - **Idle timeout**: connections can be closed if no data is sent for too long (**5 minutes** for regional/private, **30 seconds** for edge).
-- **Not supported** (streaming mode): VTL mapping templates, integration response caching, and some content encoding behaviors.
+- **Throughput**: responses larger than **10MB** can be throttled to **~2MB/s**.
+- **Not supported** (streaming mode): VTL mapping templates, integration response caching, and content encoding.
+
+### Heartbeats (Keep-Alive)
+
+To avoid idle timeouts, emit periodic SSE events even when you have no “real” updates:
+
+```go
+eventChan <- lift.SSEEvent{Event: "keepalive", Data: "ping"} // client can ignore
+```
+
+Choose a heartbeat interval **lower than your idle timeout** (for edge endpoints, assume ≤30s).
 
 ## Next: Detailed APIs and Edge Cases
 

--- a/docs/response-streaming.md
+++ b/docs/response-streaming.md
@@ -136,9 +136,36 @@ func NewStreamingAPIStack(scope constructs.Construct, id *string) awscdk.Stack {
 ```
 
 **What the construct configures:**
-- `ResponseTransferMode: STREAM` on REST API method integrations
+- `ResponseTransferMode: STREAM` on streaming-enabled REST API method integrations
 - Streaming Lambda invocation URI: `.../2021-11-15/functions/{arn}/response-streaming-invocations`
 - Optional longer integration timeout (up to 15 minutes)
+
+### Selective Streaming: Only Enable Streaming Where Needed
+
+If you only want to stream specific endpoints (for example `/events`), keep `EnableStreaming` off globally and enable it per method. This allows you to compile only the streaming Lambda with `-tags lambda.norpc`.
+
+```go
+timeoutSeconds := 15 * 60
+
+api := liftconstructs.NewLiftRestAPI(stack, jsii.String("RestAPI"), &liftconstructs.LiftRestAPIProps{
+	APICommonProps: liftconstructs.APICommonProps{
+		Name: jsii.String("my-rest-api"),
+	},
+	EnableStreaming:  jsii.Bool(false), // default: buffered
+	StreamingTimeout: &timeoutSeconds,  // used by streaming-enabled methods
+})
+
+api.AddLambdaIntegrationWithOptions(
+	jsii.String("/events"),
+	jsii.String("GET"),
+	streamingFn,
+	&liftconstructs.IntegrationOptions{
+		EnableStreaming: jsii.Bool(true), // streaming for this method only
+	},
+)
+
+api.AddLambdaIntegration(jsii.String("/health"), jsii.String("GET"), bufferedFn)
+```
 
 ### INCORRECT: HTTP API v2 expecting streaming SSE
 
@@ -154,6 +181,13 @@ api := constructs.NewLiftAPI(stack, jsii.String("HttpAPI"), &constructs.LiftAPIP
 - **SSE streaming**: one-way (server → client) over HTTP, simplest client support.
 - **WebSockets**: two-way (client ↔ server) messaging; see `docs/streamer-guide.md`.
 - **Streamer async patterns**: useful when work must continue after the request lifecycle or needs durable fanout; SSE is not durable by itself.
+
+## Platform Limits & Gotchas
+
+API Gateway response streaming has important platform behaviors:
+- **Integration timeout**: up to **15 minutes** (900 seconds) for streaming-enabled methods.
+- **Idle timeout**: connections can be closed if no data is sent for too long (**5 minutes** for regional/private, **30 seconds** for edge).
+- **Not supported** (streaming mode): VTL mapping templates, integration response caching, and some content encoding behaviors.
 
 ## Next: Detailed APIs and Edge Cases
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/aws/aws-cdk-go/awscdk/v2 v2.220.0
-	github.com/aws/aws-lambda-go v1.50.0
+	github.com/aws/aws-lambda-go v1.51.0
 	github.com/aws/aws-sdk-go-v2 v1.39.4
 	github.com/aws/aws-sdk-go-v2/config v1.31.15
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.19

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/aws/aws-cdk-go/awscdk/v2 v2.220.0 h1:2Ro9+oz5QhZ02UqAIyBoeQGGb+AvSv4A
 github.com/aws/aws-cdk-go/awscdk/v2 v2.220.0/go.mod h1:MzAbeaZ2ikHSDYMTbf/KerTp4iuO6uXvEm9k/vSCE3U=
 github.com/aws/aws-lambda-go v1.50.0 h1:0GzY18vT4EsCvIyk3kn3ZH5Jg30NRlgYaai1w0aGPMU=
 github.com/aws/aws-lambda-go v1.50.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/aws/aws-lambda-go v1.51.0 h1:/THH60NjiAs3K5TWet3Gx5w8MdR7oPOQH9utaKYY1JQ=
+github.com/aws/aws-lambda-go v1.51.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go-v2 v1.39.4 h1:qTsQKcdQPHnfGYBBs+Btl8QwxJeoWcOcPcixK90mRhg=
 github.com/aws/aws-sdk-go-v2 v1.39.4/go.mod h1:yWSxrnioGUZ4WVv9TgMrNUeLV3PFESn/v+6T/Su8gnM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.2 h1:t9yYsydLYNBk9cJ73rgPhPWqOh/52fcWDQB5b1JsKSY=

--- a/pkg/cdk/constructs/rest_api.go
+++ b/pkg/cdk/constructs/rest_api.go
@@ -18,9 +18,15 @@ type LiftRestAPIProps struct {
 	APICommonProps
 	// AppName is an alias for Name (backwards compatible).
 	AppName *string
-	// EnableStreaming enables API Gateway REST API response streaming.
+	// EnableStreaming enables API Gateway REST API response streaming by default
+	// for methods added via AddLambdaIntegration*.
+	//
+	// Methods can override this default via IntegrationOptions.EnableStreaming.
 	EnableStreaming *bool
-	// StreamingTimeout sets integration timeout in seconds (up to 15 minutes).
+	// StreamingTimeout sets the default integration timeout in seconds for streaming
+	// methods (up to 15 minutes).
+	//
+	// Methods can override this default via IntegrationOptions.StreamingTimeoutSeconds.
 	StreamingTimeout *int
 	// Certificate configures a custom domain when DomainName is set.
 	Certificate awscertificatemanager.ICertificate
@@ -40,9 +46,10 @@ type LiftRestAPI struct {
 	RestAPI  awsapigateway.RestApi
 	LogGroup awslogs.ILogGroup
 
-	// streamingTimeoutMillis is non-zero when response streaming is enabled.
-	// It is passed through to API Gateway as Integration.TimeoutInMillis.
-	streamingTimeoutMillis float64
+	// defaultStreamingEnabled controls whether methods stream by default.
+	defaultStreamingEnabled bool
+	// defaultStreamingTimeoutMillis is applied to streaming method integrations as Integration.TimeoutInMillis.
+	defaultStreamingTimeoutMillis float64
 }
 
 // GetResourceName returns the API name
@@ -85,13 +92,15 @@ func (b *liftRestAPIBuilder) build() *LiftRestAPI {
 	// Create REST API
 	restApi := b.createRestAPI(logGroup)
 
-	streamingTimeoutMillis := b.resolveStreamingTimeoutMillis()
+	defaultStreamingEnabled := b.resolveDefaultStreamingEnabled()
+	defaultStreamingTimeoutMillis := b.resolveDefaultStreamingTimeoutMillis()
 
 	return &LiftRestAPI{
-		Construct:              b.construct,
-		RestAPI:                restApi,
-		LogGroup:               logGroup,
-		streamingTimeoutMillis: streamingTimeoutMillis,
+		Construct:                     b.construct,
+		RestAPI:                       restApi,
+		LogGroup:                      logGroup,
+		defaultStreamingEnabled:       defaultStreamingEnabled,
+		defaultStreamingTimeoutMillis: defaultStreamingTimeoutMillis,
 	}
 }
 
@@ -226,12 +235,11 @@ func (b *liftRestAPIBuilder) applyDefaultAuthorizer(apiProps *awsapigateway.Rest
 	}
 }
 
-func (b *liftRestAPIBuilder) resolveStreamingTimeoutMillis() float64 {
-	if b.props.EnableStreaming == nil || !*b.props.EnableStreaming {
-		return 0
-	}
+func (b *liftRestAPIBuilder) resolveDefaultStreamingEnabled() bool {
+	return b.props.EnableStreaming != nil && *b.props.EnableStreaming
+}
 
-	// Default to 15 minutes when streaming is enabled.
+func (b *liftRestAPIBuilder) resolveDefaultStreamingTimeoutMillis() float64 {
 	timeoutSeconds := 15 * 60
 	if b.props.StreamingTimeout != nil && *b.props.StreamingTimeout > 0 {
 		timeoutSeconds = *b.props.StreamingTimeout
@@ -281,6 +289,10 @@ type IntegrationOptions struct {
 	RequestValidator awsapigateway.IRequestValidator
 	// API key required
 	ApiKeyRequired *bool
+	// EnableStreaming overrides LiftRestAPIProps.EnableStreaming for this method.
+	EnableStreaming *bool
+	// StreamingTimeoutSeconds overrides LiftRestAPIProps.StreamingTimeout for this method.
+	StreamingTimeoutSeconds *int
 }
 
 // AddLambdaIntegrationWithOptions adds a Lambda function with additional options
@@ -310,8 +322,8 @@ func (api *LiftRestAPI) AddLambdaIntegrationWithOptions(path *string, method *st
 	// Add method to resource
 	added := resource.AddMethod(method, integration, methodOptions)
 
-	if api.streamingTimeoutMillis > 0 {
-		api.configureStreamingIntegration(added, fn)
+	if streamingEnabled, timeoutMillis := api.resolveStreamingIntegration(options); streamingEnabled {
+		api.configureStreamingIntegration(added, fn, timeoutMillis)
 	}
 }
 
@@ -335,7 +347,34 @@ func (api *LiftRestAPI) getOrCreateResource(path *string) awsapigateway.IResourc
 	return current
 }
 
-func (api *LiftRestAPI) configureStreamingIntegration(method awsapigateway.Method, fn awslambda.IFunction) {
+func (api *LiftRestAPI) resolveStreamingIntegration(options *IntegrationOptions) (bool, float64) {
+	streamingEnabled := api.defaultStreamingEnabled
+	timeoutMillis := api.defaultStreamingTimeoutMillis
+
+	if options != nil {
+		if options.EnableStreaming != nil {
+			streamingEnabled = *options.EnableStreaming
+		}
+		if streamingEnabled && options.StreamingTimeoutSeconds != nil && *options.StreamingTimeoutSeconds > 0 {
+			timeoutSeconds := *options.StreamingTimeoutSeconds
+			if timeoutSeconds > 15*60 {
+				timeoutSeconds = 15 * 60
+			}
+			timeoutMillis = float64(timeoutSeconds * 1000)
+		}
+	}
+
+	if !streamingEnabled {
+		return false, 0
+	}
+	if timeoutMillis <= 0 {
+		timeoutMillis = float64(15 * 60 * 1000)
+	}
+
+	return true, timeoutMillis
+}
+
+func (api *LiftRestAPI) configureStreamingIntegration(method awsapigateway.Method, fn awslambda.IFunction, timeoutMillis float64) {
 	child := method.Node().DefaultChild()
 	cfnMethod, ok := child.(awsapigateway.CfnMethod)
 	if !ok {
@@ -355,9 +394,7 @@ func (api *LiftRestAPI) configureStreamingIntegration(method awsapigateway.Metho
 
 	cfnMethod.AddOverride(jsii.String("Properties.Integration.ResponseTransferMode"), "STREAM")
 	cfnMethod.AddOverride(jsii.String("Properties.Integration.Uri"), uri)
-	if api.streamingTimeoutMillis > 0 {
-		cfnMethod.AddOverride(jsii.String("Properties.Integration.TimeoutInMillis"), api.streamingTimeoutMillis)
-	}
+	cfnMethod.AddOverride(jsii.String("Properties.Integration.TimeoutInMillis"), timeoutMillis)
 }
 
 // CreateAPIKey creates an API key for the REST API

--- a/pkg/cdk/constructs/rest_api_streaming_test.go
+++ b/pkg/cdk/constructs/rest_api_streaming_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2/assertions"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
 	"github.com/aws/jsii-runtime-go"
-	"github.com/pay-theory/lift/pkg/cdk/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pay-theory/lift/pkg/cdk/test"
 )
 
 func TestLiftRestAPI_EnablesStreamingIntegration(t *testing.T) {
@@ -107,5 +108,151 @@ func TestLiftRestAPI_AllowsMixedStreamingAndBufferedMethods(t *testing.T) {
 	}
 
 	assert.True(t, streamingFound, "expected to find a streaming method integration")
+	assert.True(t, bufferedFound, "expected to find a buffered method integration")
+}
+
+func TestLiftRestAPI_GlobalStreamingCanBeDisabledPerMethod(t *testing.T) {
+	stack := test.NewTestStack()
+
+	api := NewLiftRestAPI(stack.Stack(), jsii.String("TestRestAPI"), &LiftRestAPIProps{
+		APICommonProps: APICommonProps{
+			Name: jsii.String("test-rest-api"),
+		},
+		EnableStreaming: jsii.Bool(true),
+	})
+
+	fn := awslambda.NewFunction(stack.Stack(), jsii.String("Fn"), &awslambda.FunctionProps{
+		Runtime: awslambda.Runtime_PROVIDED_AL2023(),
+		Handler: jsii.String("bootstrap"),
+		Code:    awslambda.Code_FromAsset(jsii.String("."), nil),
+	})
+
+	api.AddLambdaIntegration(jsii.String("/stream"), jsii.String("GET"), fn)
+	api.AddLambdaIntegrationWithOptions(jsii.String("/buffered"), jsii.String("GET"), fn, &IntegrationOptions{
+		EnableStreaming: jsii.Bool(false),
+	})
+
+	template := assertions.Template_FromStack(stack.Stack(), nil)
+	template.ResourceCountIs(jsii.String("AWS::ApiGateway::Method"), jsii.Number(2))
+
+	methods := template.FindResources(jsii.String("AWS::ApiGateway::Method"), nil)
+	require.NotNil(t, methods)
+
+	streamingFound := false
+	bufferedFound := false
+	for _, res := range *methods {
+		propsAny, ok := (*res)["Properties"]
+		require.True(t, ok, "expected Properties on method resource")
+
+		props, ok := propsAny.(map[string]any)
+		require.True(t, ok, "expected method Properties to be an object")
+
+		integrationAny, ok := props["Integration"]
+		require.True(t, ok, "expected Integration on method Properties")
+
+		integration, ok := integrationAny.(map[string]any)
+		require.True(t, ok, "expected Integration to be an object")
+
+		uriJSON, err := json.Marshal(integration["Uri"])
+		require.NoError(t, err)
+		uriStr := string(uriJSON)
+
+		switch {
+		case strings.Contains(uriStr, "response-streaming-invocations"):
+			assert.Equal(t, "STREAM", integration["ResponseTransferMode"])
+			assert.Equal(t, float64(900000), integration["TimeoutInMillis"])
+			streamingFound = true
+		case strings.Contains(uriStr, "/invocations"):
+			_, hasTransferMode := integration["ResponseTransferMode"]
+			assert.False(t, hasTransferMode, "buffered integration should not set ResponseTransferMode")
+			_, hasTimeout := integration["TimeoutInMillis"]
+			assert.False(t, hasTimeout, "buffered integration should not set TimeoutInMillis")
+			bufferedFound = true
+		}
+	}
+
+	assert.True(t, streamingFound, "expected to find a streaming method integration")
+	assert.True(t, bufferedFound, "expected to find a buffered method integration")
+}
+
+func TestLiftRestAPI_PerMethodStreamingTimeoutOverridesAndClamps(t *testing.T) {
+	stack := test.NewTestStack()
+
+	propsTimeoutSeconds := 1
+	api := NewLiftRestAPI(stack.Stack(), jsii.String("TestRestAPI"), &LiftRestAPIProps{
+		APICommonProps: APICommonProps{
+			Name: jsii.String("test-rest-api"),
+		},
+		EnableStreaming:  jsii.Bool(false),
+		StreamingTimeout: &propsTimeoutSeconds,
+	})
+
+	fn := awslambda.NewFunction(stack.Stack(), jsii.String("Fn"), &awslambda.FunctionProps{
+		Runtime: awslambda.Runtime_PROVIDED_AL2023(),
+		Handler: jsii.String("bootstrap"),
+		Code:    awslambda.Code_FromAsset(jsii.String("."), nil),
+	})
+
+	shortTimeoutSeconds := 5
+	longTimeoutSeconds := 9999
+	api.AddLambdaIntegrationWithOptions(jsii.String("/short"), jsii.String("GET"), fn, &IntegrationOptions{
+		EnableStreaming:         jsii.Bool(true),
+		StreamingTimeoutSeconds: &shortTimeoutSeconds,
+	})
+	api.AddLambdaIntegrationWithOptions(jsii.String("/clamped"), jsii.String("GET"), fn, &IntegrationOptions{
+		EnableStreaming:         jsii.Bool(true),
+		StreamingTimeoutSeconds: &longTimeoutSeconds,
+	})
+	api.AddLambdaIntegration(jsii.String("/buffered"), jsii.String("GET"), fn)
+
+	template := assertions.Template_FromStack(stack.Stack(), nil)
+	template.ResourceCountIs(jsii.String("AWS::ApiGateway::Method"), jsii.Number(3))
+
+	methods := template.FindResources(jsii.String("AWS::ApiGateway::Method"), nil)
+	require.NotNil(t, methods)
+
+	shortFound := false
+	clampedFound := false
+	bufferedFound := false
+
+	for _, res := range *methods {
+		propsAny, ok := (*res)["Properties"]
+		require.True(t, ok, "expected Properties on method resource")
+
+		props, ok := propsAny.(map[string]any)
+		require.True(t, ok, "expected method Properties to be an object")
+
+		integrationAny, ok := props["Integration"]
+		require.True(t, ok, "expected Integration on method Properties")
+
+		integration, ok := integrationAny.(map[string]any)
+		require.True(t, ok, "expected Integration to be an object")
+
+		uriJSON, err := json.Marshal(integration["Uri"])
+		require.NoError(t, err)
+		uriStr := string(uriJSON)
+
+		switch {
+		case strings.Contains(uriStr, "response-streaming-invocations"):
+			assert.Equal(t, "STREAM", integration["ResponseTransferMode"])
+			switch integration["TimeoutInMillis"] {
+			case float64(5000):
+				shortFound = true
+			case float64(900000):
+				clampedFound = true
+			default:
+				assert.Fail(t, "unexpected streaming TimeoutInMillis", "got %v", integration["TimeoutInMillis"])
+			}
+		case strings.Contains(uriStr, "/invocations"):
+			_, hasTransferMode := integration["ResponseTransferMode"]
+			assert.False(t, hasTransferMode, "buffered integration should not set ResponseTransferMode")
+			_, hasTimeout := integration["TimeoutInMillis"]
+			assert.False(t, hasTimeout, "buffered integration should not set TimeoutInMillis")
+			bufferedFound = true
+		}
+	}
+
+	assert.True(t, shortFound, "expected to find a streaming method with per-method timeout override")
+	assert.True(t, clampedFound, "expected to find a streaming method with clamped timeout")
 	assert.True(t, bufferedFound, "expected to find a buffered method integration")
 }

--- a/pkg/cdk/constructs/rest_api_streaming_test.go
+++ b/pkg/cdk/constructs/rest_api_streaming_test.go
@@ -2,6 +2,7 @@ package constructs
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2/assertions"
@@ -41,4 +42,70 @@ func TestLiftRestAPI_EnablesStreamingIntegration(t *testing.T) {
 	assert.Contains(t, templateJSON, "2021-11-15/functions")
 	assert.Contains(t, templateJSON, "\"ResponseTransferMode\":\"STREAM\"")
 	assert.Contains(t, templateJSON, "\"TimeoutInMillis\":900000")
+}
+
+func TestLiftRestAPI_AllowsMixedStreamingAndBufferedMethods(t *testing.T) {
+	stack := test.NewTestStack()
+
+	propsTimeoutSeconds := 10 * 60
+	api := NewLiftRestAPI(stack.Stack(), jsii.String("TestRestAPI"), &LiftRestAPIProps{
+		APICommonProps: APICommonProps{
+			Name: jsii.String("test-rest-api"),
+		},
+		EnableStreaming:  jsii.Bool(false),
+		StreamingTimeout: &propsTimeoutSeconds,
+	})
+
+	fn := awslambda.NewFunction(stack.Stack(), jsii.String("Fn"), &awslambda.FunctionProps{
+		Runtime: awslambda.Runtime_PROVIDED_AL2023(),
+		Handler: jsii.String("bootstrap"),
+		Code:    awslambda.Code_FromAsset(jsii.String("."), nil),
+	})
+
+	api.AddLambdaIntegrationWithOptions(jsii.String("/stream"), jsii.String("GET"), fn, &IntegrationOptions{
+		EnableStreaming: jsii.Bool(true),
+	})
+	api.AddLambdaIntegration(jsii.String("/buffered"), jsii.String("GET"), fn)
+
+	template := assertions.Template_FromStack(stack.Stack(), nil)
+	template.ResourceCountIs(jsii.String("AWS::ApiGateway::Method"), jsii.Number(2))
+
+	methods := template.FindResources(jsii.String("AWS::ApiGateway::Method"), nil)
+	require.NotNil(t, methods)
+
+	streamingFound := false
+	bufferedFound := false
+	for _, res := range *methods {
+		propsAny, ok := (*res)["Properties"]
+		require.True(t, ok, "expected Properties on method resource")
+
+		props, ok := propsAny.(map[string]any)
+		require.True(t, ok, "expected method Properties to be an object")
+
+		integrationAny, ok := props["Integration"]
+		require.True(t, ok, "expected Integration on method Properties")
+
+		integration, ok := integrationAny.(map[string]any)
+		require.True(t, ok, "expected Integration to be an object")
+
+		uriJSON, err := json.Marshal(integration["Uri"])
+		require.NoError(t, err)
+		uriStr := string(uriJSON)
+
+		switch {
+		case strings.Contains(uriStr, "response-streaming-invocations"):
+			assert.Equal(t, "STREAM", integration["ResponseTransferMode"])
+			assert.Equal(t, float64(600000), integration["TimeoutInMillis"])
+			streamingFound = true
+		case strings.Contains(uriStr, "/invocations"):
+			_, hasTransferMode := integration["ResponseTransferMode"]
+			assert.False(t, hasTransferMode, "buffered integration should not set ResponseTransferMode")
+			_, hasTimeout := integration["TimeoutInMillis"]
+			assert.False(t, hasTimeout, "buffered integration should not set TimeoutInMillis")
+			bufferedFound = true
+		}
+	}
+
+	assert.True(t, streamingFound, "expected to find a streaming method integration")
+	assert.True(t, bufferedFound, "expected to find a buffered method integration")
 }

--- a/pkg/lift/streaming.go
+++ b/pkg/lift/streaming.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 
 	"github.com/aws/aws-lambda-go/events"
+
+	"github.com/pay-theory/lift/pkg/lift/adapters"
 )
 
 // SSEEvent represents a single Server-Sent Event.
@@ -69,7 +71,12 @@ func (c *Context) clearStreamingState() {
 
 // SSEResponse configures a streaming response that emits SSE-formatted events
 // from eventChan. This requires the Lambda integration to be configured for
-// response streaming (for example API Gateway REST API with STREAM transfer).
+// response streaming (for example API Gateway REST API v1 with STREAM transfer).
+//
+// When invoked via API Gateway REST API (v1), Lift returns an
+// events.APIGatewayProxyStreamingResponse (supports multiValueHeaders). For
+// other trigger types, Lift returns an events.LambdaFunctionURLStreamingResponse
+// for compatibility with Function URL response streaming.
 //
 // Note: AWS Lambda response streaming in Go requires compiling with
 // `-tags lambda.norpc` (or using a provided runtime) when deployed.
@@ -86,13 +93,21 @@ func SSEResponse(ctx *Context, eventChan <-chan SSEEvent) error {
 	headers := map[string]string{
 		HeaderContentType: "text/event-stream",
 		"Cache-Control":   "no-cache",
-		"Connection":      "keep-alive",
 	}
 
-	streamingResp := &events.LambdaFunctionURLStreamingResponse{
-		StatusCode: 200,
-		Headers:    headers,
-		Body:       pipeReader,
+	var streamingResp any
+	if ctx.Request != nil && ctx.Request.TriggerType == adapters.TriggerAPIGateway {
+		streamingResp = &events.APIGatewayProxyStreamingResponse{
+			StatusCode: 200,
+			Headers:    headers,
+			Body:       pipeReader,
+		}
+	} else {
+		streamingResp = &events.LambdaFunctionURLStreamingResponse{
+			StatusCode: 200,
+			Headers:    headers,
+			Body:       pipeReader,
+		}
 	}
 
 	// Keep the standard Lift response in sync for middleware that inspects it

--- a/pkg/lift/streaming.go
+++ b/pkg/lift/streaming.go
@@ -39,6 +39,51 @@ type streamingState struct {
 
 const streamingStateKey = "__lift_streaming_state"
 const requestCancelKey = "__lift_request_cancel"
+const responseMultiValueHeadersKey = "__lift_response_multi_value_headers"
+
+// AddMultiValueHeader appends a response header value under the same header
+// name (multi-value headers).
+//
+// This is currently applied only when Lift returns an API Gateway REST API (v1)
+// streaming response (events.APIGatewayProxyStreamingResponse), which supports
+// the `multiValueHeaders` response metadata field.
+func (c *Context) AddMultiValueHeader(key, value string) {
+	if c == nil {
+		return
+	}
+	if key == "" {
+		return
+	}
+	headers := c.getOrCreateMultiValueResponseHeaders()
+	headers[key] = append(headers[key], value)
+}
+
+func (c *Context) getOrCreateMultiValueResponseHeaders() map[string][]string {
+	if c == nil {
+		return nil
+	}
+	existing := c.Get(responseMultiValueHeadersKey)
+	headers, ok := existing.(map[string][]string)
+	if ok && headers != nil {
+		return headers
+	}
+
+	headers = make(map[string][]string)
+	c.Set(responseMultiValueHeadersKey, headers)
+	return headers
+}
+
+func (c *Context) multiValueResponseHeaders() map[string][]string {
+	if c == nil {
+		return nil
+	}
+	existing := c.Get(responseMultiValueHeadersKey)
+	headers, ok := existing.(map[string][]string)
+	if !ok {
+		return nil
+	}
+	return headers
+}
 
 func (c *Context) setStreamingState(state *streamingState) {
 	if c == nil {
@@ -69,6 +114,101 @@ func (c *Context) clearStreamingState() {
 	delete(c.values, streamingStateKey)
 }
 
+func validateSSEResponseInputs(ctx *Context, eventChan <-chan SSEEvent) error {
+	if ctx == nil {
+		return errors.New("lift: nil context")
+	}
+	if eventChan == nil {
+		return errors.New("lift: nil event channel")
+	}
+	return nil
+}
+
+func buildSSEHeaders(ctx *Context) map[string]string {
+	headers := map[string]string{}
+	if ctx != nil && ctx.Response != nil && ctx.Response.Headers != nil {
+		for k, v := range ctx.Response.Headers {
+			headers[k] = v
+		}
+	}
+
+	headers[HeaderContentType] = "text/event-stream"
+	headers["Cache-Control"] = "no-cache"
+
+	return headers
+}
+
+func buildStreamingResponse(ctx *Context, reader io.Reader, headers map[string]string, multiValueHeaders map[string][]string) any {
+	if ctx != nil && ctx.Request != nil && ctx.Request.TriggerType == adapters.TriggerAPIGateway {
+		return &events.APIGatewayProxyStreamingResponse{
+			StatusCode:        200,
+			Headers:           headers,
+			MultiValueHeaders: multiValueHeaders,
+			Body:              reader,
+		}
+	}
+
+	return &events.LambdaFunctionURLStreamingResponse{
+		StatusCode: 200,
+		Headers:    headers,
+		Body:       reader,
+	}
+}
+
+func syncStreamingHeadersToLiftResponse(ctx *Context, headers map[string]string) {
+	if ctx == nil || ctx.Response == nil {
+		return
+	}
+
+	ctx.Response.StatusCode = 200
+	if ctx.Response.Headers == nil {
+		ctx.Response.Headers = make(map[string]string)
+	}
+	for k, v := range headers {
+		ctx.Response.Headers[k] = v
+	}
+}
+
+func requestCancelFunc(ctx *Context) context.CancelFunc {
+	if ctx == nil {
+		return nil
+	}
+	cancelAny := ctx.Get(requestCancelKey)
+	cancel, ok := cancelAny.(context.CancelFunc)
+	if !ok {
+		return nil
+	}
+	return cancel
+}
+
+func newSSEStartFn(ctx context.Context, writer *io.PipeWriter, eventChan <-chan SSEEvent, cancel context.CancelFunc) func() {
+	var startOnce sync.Once
+	return func() {
+		startOnce.Do(func() {
+			go func() {
+				streamSSE(ctx, writer, eventChan)
+				if cancel != nil {
+					cancel()
+				}
+			}()
+		})
+	}
+}
+
+func newSSEAbortFn(writer *io.PipeWriter) func(error) {
+	return func(err error) {
+		if err == nil {
+			if closeErr := writer.Close(); closeErr != nil {
+				_ = closeErr
+			}
+			return
+		}
+		if closeErr := writer.CloseWithError(err); closeErr != nil {
+			_ = closeErr
+		}
+	}
+}
+
 // SSEResponse configures a streaming response that emits SSE-formatted events
 // from eventChan. This requires the Lambda integration to be configured for
 // response streaming (for example API Gateway REST API v1 with STREAM transfer).
@@ -81,75 +221,22 @@ func (c *Context) clearStreamingState() {
 // Note: AWS Lambda response streaming in Go requires compiling with
 // `-tags lambda.norpc` (or using a provided runtime) when deployed.
 func SSEResponse(ctx *Context, eventChan <-chan SSEEvent) error {
-	if ctx == nil {
-		return errors.New("lift: nil context")
-	}
-	if eventChan == nil {
-		return errors.New("lift: nil event channel")
+	if err := validateSSEResponseInputs(ctx, eventChan); err != nil {
+		return err
 	}
 
 	pipeReader, pipeWriter := io.Pipe()
 
-	headers := map[string]string{
-		HeaderContentType: "text/event-stream",
-		"Cache-Control":   "no-cache",
-	}
-
-	var streamingResp any
-	if ctx.Request != nil && ctx.Request.TriggerType == adapters.TriggerAPIGateway {
-		streamingResp = &events.APIGatewayProxyStreamingResponse{
-			StatusCode: 200,
-			Headers:    headers,
-			Body:       pipeReader,
-		}
-	} else {
-		streamingResp = &events.LambdaFunctionURLStreamingResponse{
-			StatusCode: 200,
-			Headers:    headers,
-			Body:       pipeReader,
-		}
-	}
+	headers := buildSSEHeaders(ctx)
+	multiValueHeaders := ctx.multiValueResponseHeaders()
+	streamingResp := buildStreamingResponse(ctx, pipeReader, headers, multiValueHeaders)
 
 	// Keep the standard Lift response in sync for middleware that inspects it
 	// (e.g. logging).
-	if ctx.Response != nil {
-		ctx.Response.StatusCode = 200
-		if ctx.Response.Headers == nil {
-			ctx.Response.Headers = make(map[string]string)
-		}
-		for k, v := range headers {
-			ctx.Response.Headers[k] = v
-		}
-	}
+	syncStreamingHeadersToLiftResponse(ctx, headers)
 
-	var startOnce sync.Once
-	cancelAny := ctx.Get(requestCancelKey)
-	cancel, ok := cancelAny.(context.CancelFunc)
-	if !ok {
-		cancel = nil
-	}
-	startFn := func() {
-		startOnce.Do(func() {
-			go func() {
-				streamSSE(ctx.Context, pipeWriter, eventChan)
-				if cancel != nil {
-					cancel()
-				}
-			}()
-		})
-	}
-
-	abortFn := func(err error) {
-		if err == nil {
-			if closeErr := pipeWriter.Close(); closeErr != nil {
-				_ = closeErr
-			}
-			return
-		}
-		if closeErr := pipeWriter.CloseWithError(err); closeErr != nil {
-			_ = closeErr
-		}
-	}
+	startFn := newSSEStartFn(ctx.Context, pipeWriter, eventChan, requestCancelFunc(ctx))
+	abortFn := newSSEAbortFn(pipeWriter)
 
 	ctx.setStreamingState(&streamingState{
 		response: streamingResp,

--- a/pkg/lift/streaming_test.go
+++ b/pkg/lift/streaming_test.go
@@ -24,7 +24,7 @@ func TestSSEResponse_ReturnsStreamingResponse(t *testing.T) {
 	respAny, err := app.HandleRequest(context.Background(), newAPIGatewayV1Event("GET", "/stream"))
 	require.NoError(t, err)
 
-	streamingResp, ok := respAny.(*events.LambdaFunctionURLStreamingResponse)
+	streamingResp, ok := respAny.(*events.APIGatewayProxyStreamingResponse)
 	require.True(t, ok, "expected streaming response, got %T", respAny)
 
 	body, err := io.ReadAll(streamingResp)
@@ -39,6 +39,31 @@ func TestSSEResponse_ReturnsStreamingResponse(t *testing.T) {
 	require.Contains(t, bodyStr, "data: goodbye\n\n")
 }
 
+func TestSSEResponse_ReturnsFunctionURLStreamingResponseForNonV1Triggers(t *testing.T) {
+	app := New()
+
+	require.NoError(t, app.GET("/stream", func(ctx *Context) error {
+		eventChan := make(chan SSEEvent, 1)
+		eventChan <- SSEEvent{Data: "hello"}
+		close(eventChan)
+
+		return SSEResponse(ctx, eventChan)
+	}))
+
+	respAny, err := app.HandleRequest(context.Background(), newAPIGatewayV2Event("GET", "/stream"))
+	require.NoError(t, err)
+
+	streamingResp, ok := respAny.(*events.LambdaFunctionURLStreamingResponse)
+	require.True(t, ok, "expected function-url streaming response, got %T", respAny)
+
+	body, err := io.ReadAll(streamingResp)
+	require.NoError(t, err)
+
+	bodyStr := string(body)
+	require.Contains(t, bodyStr, "text/event-stream")
+	require.Contains(t, bodyStr, "data: hello\n\n")
+}
+
 func newAPIGatewayV1Event(method, path string) map[string]any {
 	return map[string]any{
 		"resource":   path,
@@ -50,6 +75,22 @@ func newAPIGatewayV1Event(method, path string) map[string]any {
 			"stage":            "prod",
 			"requestTimeEpoch": "0",
 		},
+		"isBase64Encoded": false,
+	}
+}
+
+func newAPIGatewayV2Event(method, path string) map[string]any {
+	return map[string]any{
+		"version":  "2.0",
+		"routeKey": method + " " + path,
+		"rawPath":  path,
+		"requestContext": map[string]any{
+			"http": map[string]any{
+				"method": method,
+				"path":   path,
+			},
+		},
+		"headers":         map[string]any{},
 		"isBase64Encoded": false,
 	}
 }

--- a/pkg/lift/streaming_test.go
+++ b/pkg/lift/streaming_test.go
@@ -1,7 +1,9 @@
 package lift
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"testing"
 
@@ -13,6 +15,10 @@ func TestSSEResponse_ReturnsStreamingResponse(t *testing.T) {
 	app := New()
 
 	require.NoError(t, app.GET("/stream", func(ctx *Context) error {
+		ctx.Response.Header("X-Custom", "1")
+		ctx.AddMultiValueHeader("X-Multi", "a")
+		ctx.AddMultiValueHeader("X-Multi", "b")
+
 		eventChan := make(chan SSEEvent, 2)
 		eventChan <- SSEEvent{Data: "hello"}
 		eventChan <- SSEEvent{ID: "1", Event: "done", Data: "goodbye", Retry: 500}
@@ -30,13 +36,50 @@ func TestSSEResponse_ReturnsStreamingResponse(t *testing.T) {
 	body, err := io.ReadAll(streamingResp)
 	require.NoError(t, err)
 
-	bodyStr := string(body)
-	require.Contains(t, bodyStr, "text/event-stream")
-	require.Contains(t, bodyStr, "data: hello\n\n")
-	require.Contains(t, bodyStr, "id: 1\n")
-	require.Contains(t, bodyStr, "event: done\n")
-	require.Contains(t, bodyStr, "retry: 500\n")
-	require.Contains(t, bodyStr, "data: goodbye\n\n")
+	delimiter := make([]byte, 8)
+	delimiterIndex := bytes.Index(body, delimiter)
+	require.NotEqual(t, -1, delimiterIndex, "expected 8-byte delimiter in streaming response prelude")
+
+	metadata := body[:delimiterIndex]
+	payload := body[delimiterIndex+len(delimiter):]
+
+	require.NotEmpty(t, metadata, "expected streaming response metadata")
+
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(metadata, &meta))
+	require.Equal(t, float64(200), meta["statusCode"])
+
+	for k := range meta {
+		switch k {
+		case "statusCode", "headers", "multiValueHeaders", "cookies":
+		default:
+			require.Fail(t, "unexpected metadata key", "key=%s", k)
+		}
+	}
+
+	payloadStr := string(payload)
+	require.Contains(t, payloadStr, "data: hello\n\n")
+	require.Contains(t, payloadStr, "id: 1\n")
+	require.Contains(t, payloadStr, "event: done\n")
+	require.Contains(t, payloadStr, "retry: 500\n")
+	require.Contains(t, payloadStr, "data: goodbye\n\n")
+
+	headersAny := meta["headers"]
+	headers, ok := headersAny.(map[string]any)
+	require.True(t, ok, "expected headers to be an object")
+	require.Equal(t, "text/event-stream", headers[HeaderContentType])
+	require.Equal(t, "1", headers["X-Custom"])
+
+	multiHeadersAny := meta["multiValueHeaders"]
+	multiHeaders, ok := multiHeadersAny.(map[string]any)
+	require.True(t, ok, "expected multiValueHeaders to be an object")
+
+	valuesAny := multiHeaders["X-Multi"]
+	values, ok := valuesAny.([]any)
+	require.True(t, ok, "expected multiValueHeaders[X-Multi] to be an array")
+	require.Len(t, values, 2)
+	require.Contains(t, values, "a")
+	require.Contains(t, values, "b")
 }
 
 func TestSSEResponse_ReturnsFunctionURLStreamingResponseForNonV1Triggers(t *testing.T) {


### PR DESCRIPTION
…s and update `SSEResponse` for API Gateway v1 streaming.