### PR TITLE
Feature/sqs s3 offload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ reference
 # Go caches (never commit)
 .gomodcache/
 .gocache/
+.golangci-lint-cache/
 
 # Local upstream clones (never commit)
 upstream/

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,10 @@ reference
 .gomodcache/
 .gocache/
 
+# Local upstream clones (never commit)
+upstream/
+.upstream/
+
 # direnv and local env shells
 .direnv/
 .envrc

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@
 # Local Go caches (sandbox-safe)
 GOCACHE ?= $(CURDIR)/.gocache
 GOMODCACHE ?= $(CURDIR)/.gomodcache
+GOLANGCI_LINT_CACHE ?= $(CURDIR)/.golangci-lint-cache
 export GOCACHE
 export GOMODCACHE
+export GOLANGCI_LINT_CACHE
 
 # Discover only packages that contain tests under ./pkg and selected roots.
 # This avoids building unrelated packages (e.g., stacks) and excludes examples.
@@ -16,7 +18,7 @@ all: test build
 
 # Ensure local cache directories exist
 cache-dirs:
-	mkdir -p $(GOCACHE) $(GOMODCACHE)
+	mkdir -p $(GOCACHE) $(GOMODCACHE) $(GOLANGCI_LINT_CACHE)
 
 # Run unit tests (exclude examples/ across the repo)
 test: cache-dirs

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@
 ### 🏗️ CDK Documentation
 - [CDK Index](./cdk.md) - Deploy Lift apps with AWS CDK (CloudFront, S3, events)
 - [CDK API Reference](./cdk-api-reference.md) - Constructs, patterns, and stacks
+- [SQS Large Payloads via S3](./cdk-sqs-large-payloads.md) - Offload SQS bodies >256KB to S3 (delete-on-success + TTL fallback)
 
 ### 🔧 CLI Documentation
 - [CLI Getting Started](./cli-getting-started.md) - Install the CLI, create projects, deploy

--- a/docs/cdk-sqs-large-payloads.md
+++ b/docs/cdk-sqs-large-payloads.md
@@ -1,0 +1,235 @@
+# SQS Large Payloads via S3 (Lift)
+
+AWS SQS message bodies have a hard limit of **256KB**. Lift supports an “extended payload” pattern where oversized message bodies are stored in S3 and SQS carries a small pointer envelope.
+
+## Table of Contents
+
+- [How It Works](#how-it-works)
+- [CDK: Enable Large Payloads](#cdk-enable-large-payloads)
+- [Go: Producer Offload Pattern](#go-producer-offload-pattern)
+- [Go + Lift: Consumer Hydrate + Delete](#go--lift-consumer-hydrate--delete)
+- [Configuration Reference](#configuration-reference)
+- [Operational Notes](#operational-notes)
+
+## How It Works
+
+### Offload Rule (No Compression)
+
+- If the serialized SQS message body is **> 256KB**, Lift offloads it to S3 (**no gzip**) and sends a pointer envelope through SQS instead.
+- Threshold is fixed at `> 256KB` (`sqslargepayload.SQSMaxMessageBytes`).
+
+### Pointer Envelope Schema
+
+When offloaded, the SQS message body becomes JSON:
+
+```json
+{
+  "type": "lift:sqs-large-payload:v1",
+  "bucket": "myapp-live-sqs-large-payload",
+  "key": "sqs/orders-queue-live/messages/01J.../payload.json",
+  "sha256": "optional",
+  "bytes": 123456
+}
+```
+
+Notes:
+- The envelope is **self-describing** (`bucket` + `key`) so consumers don’t need bucket env vars to hydrate/delete.
+- `sha256` is optional; Lift verifies it by default when present.
+
+### Delete-On-Success + TTL Fallback
+
+- Consumers **explicitly delete** the S3 object after successful processing.
+- The bucket is configured with an S3 lifecycle **expiration TTL** (default: **7 days**) as a safety net for leak cleanup.
+
+## CDK: Enable Large Payloads
+
+Enable the feature on `constructs.SQSProcessor` via `SQSProcessorProps.LargePayload`:
+
+```go
+processor := constructs.NewSQSProcessor(stack, jsii.String("Jobs"), &constructs.SQSProcessorProps{
+    FunctionProps: awslambda.FunctionProps{
+        FunctionName: jsii.String("jobs-processor"),
+        Code:         awslambda.Code_FromAsset(jsii.String("./dist"), nil),
+        Runtime:      awslambda.Runtime_PROVIDED_AL2023(),
+    },
+    LargePayload: &constructs.SQSLargePayloadProps{}, // opt-in
+})
+
+// For wiring producers:
+// - bucket:  processor.LargePayloadBucket
+// - prefix:  *processor.LargePayloadPrefix
+// - grants:  processor.GrantLargePayloadPublish(fn) / processor.GrantLargePayloadConsume(fn)
+_ = processor
+```
+
+### Producer Wiring (Recommended)
+
+The consumer Lambda (the processor function) automatically receives `s3:GetObject` + `s3:DeleteObject` scoped to the payload prefix.
+
+For a producer Lambda that offloads payloads, grant write permissions and pass the bucket/prefix to your producer code:
+
+```go
+producerFn := constructs.NewLiftFunction(stack, jsii.String("Producer"), &constructs.LiftFunctionProps{
+    FunctionProps: awslambda.FunctionProps{
+        FunctionName: jsii.String("jobs-producer"),
+        Code:         awslambda.Code_FromAsset(jsii.String("./dist-producer"), nil),
+        Runtime:      awslambda.Runtime_PROVIDED_AL2023(),
+    },
+})
+
+processor.GrantLargePayloadPublish(producerFn.Function)
+
+producerFn.Function.AddEnvironment(jsii.String("LIFT_SQS_LARGE_PAYLOAD_BUCKET"), processor.LargePayloadBucket.BucketName(), nil)
+producerFn.Function.AddEnvironment(jsii.String("LIFT_SQS_LARGE_PAYLOAD_PREFIX"), processor.LargePayloadPrefix, nil)
+```
+
+Lift also supports deterministic bucket naming when the naming context is available:
+- Required: `APP_NAME`, `STAGE`
+- Optional: `PARTNER`
+
+If you want producers to derive bucket names at runtime (instead of injecting bucket env vars), ensure the bucket is created with a deterministic name (or explicitly set `BucketProps.BucketName`) and use `pkg/naming` in producer code.
+
+## Go: Producer Offload Pattern
+
+Use `pkg/services/sqs_large_payload` to offload when needed and send either the original body or an envelope as the SQS message body.
+
+```go
+import (
+    "context"
+    "crypto/rand"
+    "encoding/hex"
+    "fmt"
+
+    "github.com/aws/aws-sdk-go-v2/config"
+    "github.com/aws/aws-sdk-go-v2/service/s3"
+    "github.com/aws/aws-sdk-go-v2/service/sqs"
+    "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+    sqslargepayload "github.com/pay-theory/lift/pkg/services/sqs_large_payload"
+)
+
+func randomHex(n int) string {
+    b := make([]byte, n)
+    _, _ = rand.Read(b)
+    return hex.EncodeToString(b)
+}
+
+func send(ctx context.Context, queueURL, bucket, prefix string, payload []byte) error {
+    awsCfg, err := config.LoadDefaultConfig(ctx)
+    if err != nil {
+        return err
+    }
+
+    s3Store := sqslargepayload.NewS3Store(s3.NewFromConfig(awsCfg))
+
+    // Pick a unique key under the configured prefix.
+    key := fmt.Sprintf("%s%s.json", prefix, randomHex(16))
+
+    body, _, err := sqslargepayload.OffloadIfNeeded(
+        ctx,
+        s3Store,
+        sqslargepayload.Ref{Bucket: bucket, Key: key},
+        payload,
+        sqslargepayload.DefaultOptions(),
+    )
+    if err != nil {
+        return err
+    }
+
+    _, err = sqs.NewFromConfig(awsCfg).SendMessage(ctx, &sqs.SendMessageInput{
+        QueueUrl:    &queueURL,
+        MessageBody: awsString(string(body)),
+        MessageAttributes: map[string]types.MessageAttributeValue{
+            "contentType": {DataType: awsString("String"), StringValue: awsString("application/json")},
+        },
+    })
+    return err
+}
+
+func awsString(s string) *string { return &s }
+```
+
+## Go + Lift: Consumer Hydrate + Delete
+
+In a Lift SQS handler, use `sqslargepayload.BatchProcessor` to hydrate a mixed batch (inline + envelopes), build `BatchItemFailures`, and delete S3 objects only for successful messages.
+
+Important: the Lambda return value for partial batch failure is `events.SQSEventResponse` (not an API Gateway proxy response). Lift handlers that return a response must use the `(any, error)` signature and return an `events.SQSEventResponse` value.
+
+```go
+import (
+    "context"
+    "encoding/json"
+    "errors"
+
+    "github.com/aws/aws-lambda-go/events"
+    "github.com/aws/aws-sdk-go-v2/config"
+    "github.com/aws/aws-sdk-go-v2/service/s3"
+    "github.com/pay-theory/lift/pkg/lift"
+    sqslargepayload "github.com/pay-theory/lift/pkg/services/sqs_large_payload"
+)
+
+type Job struct {
+    ID string `json:"id"`
+}
+
+func main() {
+    app := lift.New()
+
+    // Create S3Store once and reuse it.
+    awsCfg, err := config.LoadDefaultConfig(context.Background())
+    if err != nil {
+        panic(err)
+    }
+    store := sqslargepayload.NewS3Store(s3.NewFromConfig(awsCfg))
+
+    processor := sqslargepayload.BatchProcessor{
+        Store:   store,
+        Options: sqslargepayload.DefaultOptions(),
+    }
+
+    _ = app.SQS("*", func(ctx *lift.Context) (any, error) {
+        records, err := ctx.SQSRecords()
+        if err != nil {
+            return events.SQSEventResponse{}, err
+        }
+
+        return processor.Process(ctx.Context, records, func(ctx context.Context, msg sqslargepayload.Message) error {
+            var job Job
+            if err := json.Unmarshal(msg.Payload, &job); err != nil {
+                return err
+            }
+            if job.ID == "" {
+                return errors.New("missing job.id")
+            }
+            return nil
+        })
+    })
+
+    lift.Start(app)
+}
+```
+
+## Configuration Reference
+
+### `constructs.SQSLargePayloadProps`
+
+```go
+type SQSLargePayloadProps struct {
+    Enabled        *bool
+    ExistingBucket awss3.IBucket
+    BucketProps    *awss3.BucketProps
+    Prefix         *string
+    Expiration     awscdk.Duration // default: 7 days (TTL fallback)
+}
+```
+
+### Defaults
+
+- Bucket secure defaults: block public access, S3-managed encryption, SSL enforced.
+- Lifecycle expiration rule is applied (default: 7 days). When Lift creates a shared default bucket, the rule is scoped to the derived prefix.
+- `constructs.SQSProcessor` defaults `ReportBatchItemFailures` to `true`.
+
+## Operational Notes
+
+- This pattern is compatible with at-least-once delivery; keep handlers idempotent.
+- If S3 delete fails, TTL will eventually clean up; you can set `BatchProcessor.FailOnDeleteError` if you prefer deletes to mark the message as failed.
+- If your producer needs deterministic bucket naming without explicit env injection, set `APP_NAME` and `STAGE` for both synth and runtime (or explicitly set `BucketProps.BucketName`).

--- a/docs/cdk-sqs-large-payloads.md
+++ b/docs/cdk-sqs-large-payloads.md
@@ -36,6 +36,23 @@ Notes:
 - The envelope is **self-describing** (`bucket` + `key`) so consumers don’t need bucket env vars to hydrate/delete.
 - `sha256` is optional; Lift verifies it by default when present.
 
+### Compatibility: Amazon SQS Extended Client Libraries (Java/Python)
+
+Lift’s consumer helper (`sqslargepayload.BatchProcessor`) also supports messages produced by the Amazon SQS extended client libraries (including the legacy system library `amazon-sqs-python-extended-client-lib`).
+
+Those libraries store the payload in S3 and send a pointer in the SQS message body as a JSON array:
+
+```json
+[
+  "software.amazon.payloadoffloading.PayloadS3Pointer",
+  { "s3BucketName": "my-bucket", "s3Key": "uuid-or-key" }
+]
+```
+
+Notes:
+- These messages often include a reserved message attribute (`ExtendedPayloadSize` or legacy `SQSLargePayloadSize`).
+- `Message.Envelope` is only set for Lift’s own `lift:sqs-large-payload:v1` envelopes; extended-client pointers are hydrated the same way, but without a Lift envelope object.
+
 ### Delete-On-Success + TTL Fallback
 
 - Consumers **explicitly delete** the S3 object after successful processing.
@@ -88,6 +105,8 @@ Lift also supports deterministic bucket naming when the naming context is availa
 - Optional: `PARTNER`
 
 If you want producers to derive bucket names at runtime (instead of injecting bucket env vars), ensure the bucket is created with a deterministic name (or explicitly set `BucketProps.BucketName`) and use `pkg/naming` in producer code.
+
+If you are consuming messages produced by an external extended-client producer, ensure the consumer Lambda has `s3:GetObject` and `s3:DeleteObject` access to the bucket/key pattern used by that producer. For producers that write keys at the bucket root (no prefix), set `LargePayload.Prefix` to `""` to grant `*` access within the bucket.
 
 ## Go: Producer Offload Pattern
 

--- a/docs/cdk.md
+++ b/docs/cdk.md
@@ -12,6 +12,7 @@ The Lift CDK package (`pkg/cdk`) provides high-level constructs and patterns for
 - [CDK Getting Started](./cdk-getting-started.md) - Step-by-step CDK setup for Lift
 - [CDK Integration Guide](./cdk-guide.md) - Deep dive into constructs and patterns
 - [CDK API Reference](./cdk-api-reference.md) - Full construct/pattern reference with code locations
+- [SQS Large Payloads via S3](./cdk-sqs-large-payloads.md) - Offload SQS bodies >256KB to S3 (pointer envelopes)
 - [API Documentation](/pkg/cdk/README.md) - Detailed construct and pattern reference
 - [Examples](/pkg/cdk/examples/) - Working examples of CDK deployments
 - [CloudFront Patterns](./cdk-cloudfront-patterns.md) - Static sites, media CDN, redirects

--- a/docs/planning/sqs-large-payload-s3.md
+++ b/docs/planning/sqs-large-payload-s3.md
@@ -1,0 +1,207 @@
+# SQS Large Payload via S3 (Extend `SQSProcessorProps`) Roadmap
+
+Status: draft (for alignment)
+
+<!-- AI Training Signal: This document is a product/engineering roadmap for adding first-class "SQS extended payloads" support to Lift. -->
+
+## Problem Statement
+
+AWS SQS message bodies have a hard limit of **256KB**. Some Lift workloads need durable queue semantics (SQS retries/DLQ, batching, concurrency control) while carrying payloads larger than 256KB.
+
+We want Lift to support the common “extended payload” pattern:
+
+- **Producer** stores the full payload in S3 when it would exceed SQS limits.
+- Producer publishes an SQS message containing a **small pointer envelope** to the S3 object.
+- **Consumer** hydrates the message from S3 and **deletes the S3 object on successful processing** (with lifecycle TTL as a safety net).
+
+This mirrors an existing production pattern used in other systems (S3 overflow for payload limits), but adapted for SQS.
+
+## Goals
+
+1. **CDK support (one-line opt-in)**: Extend `constructs.SQSProcessorProps` with a payload-bucket option that provisions and wires an S3 bucket for large payload storage with secure defaults.
+2. **Runtime helpers (Go)**: Provide Lift helper code to:
+   - offload oversized payloads to S3 (no gzip)
+   - generate and parse a pointer envelope
+   - hydrate messages from S3
+   - delete S3 objects on success
+3. **Correct SQS failure semantics**: Support **partial batch failure** (`ReportBatchItemFailures`) so successful messages do not retry, enabling safe per-message S3 deletion.
+4. **Minimal configuration / derived naming**:
+   - Do not require a large set of env vars to operate.
+   - Prefer deterministic/derived resource names in CDK (using Lift naming conventions) when naming context is available.
+   - Ensure the pointer envelope is **self-describing** (`bucket` + `key`) so consumers do not need bucket env vars.
+
+## Non-Goals
+
+- Compression (explicitly **no gzip**).
+- Changing SQS limits or supporting “chunking” across multiple SQS messages.
+- Cross-account payload buckets or complex multi-region replication.
+- A full event-orchestration system (this is specifically about SQS payload size limits).
+
+## Proposed Design (High-Level)
+
+### Offload rule
+
+- If the serialized message body is **> 256KB**, store it in S3 and send an SQS pointer envelope instead.
+- Threshold is fixed; no runtime tuning required.
+
+### Pointer envelope (SQS message body)
+
+SQS message body becomes a small JSON object:
+
+```json
+{
+  "type": "lift:sqs-large-payload:v1",
+  "bucket": "myapp-live-sqs-large-payload",
+  "key": "sqs/orders-queue-live/messages/01J.../payload.json",
+  "sha256": "…optional…",
+  "bytes": 123456
+}
+```
+
+Notes:
+- Include `bucket` and `key` so consumers can hydrate/delete without environment configuration.
+- Include `type` for unambiguous detection.
+- `sha256` is optional but recommended for integrity checks.
+
+### Deletion policy
+
+- **Delete from S3 on success** (per message).
+- Configure S3 lifecycle TTL as a fallback for leak cleanup (e.g., 7–14 days; default should align with typical SQS retention/workflow duration).
+
+### Naming strategy (CDK)
+
+- When stable naming inputs exist, derive deterministic bucket names using Lift’s `pkg/naming` conventions.
+- When not available, allow CDK to auto-name resources; the pointer envelope will still include the resolved bucket name at publish time.
+
+## Milestones
+
+### Milestone 1 — Spec & Public API (CDK + Runtime)
+
+**Deliverables**
+- Define `SQSLargePayloadProps` and add it to `constructs.SQSProcessorProps`:
+  - enable/disable
+  - `ExistingBucket` or `BucketProps` (create-if-nil)
+  - lifecycle TTL configuration
+  - optional prefix override (default derived from queue name)
+- Define pointer envelope schema and Go types.
+- Define the runtime helper surface (package name, function signatures, errors).
+
+**Acceptance Criteria**
+- A single document section (this roadmap + API reference update later) defines:
+  - envelope JSON schema and versioning (`lift:sqs-large-payload:v1`)
+  - offload threshold rule (`> 256KB`)
+  - deletion policy (delete on success + TTL fallback)
+- The `SQSProcessorProps` extension is backward-compatible (existing code compiles unchanged).
+
+---
+
+### Milestone 2 — CDK: Extend `SQSProcessor` with S3 Payload Bucket
+
+**Deliverables**
+- Implement bucket creation/attachment inside `NewSQSProcessor` when `LargePayload` is enabled:
+  - Secure defaults: block public access, encryption, lifecycle expiration.
+  - Prefix-scoped IAM: grant the processor Lambda `s3:GetObject` + `s3:DeleteObject` for the prefix.
+- Expose on the construct:
+  - `LargePayloadBucket` (bucket reference)
+  - `LargePayloadPrefix` (string)
+  - helper grants: `GrantLargePayloadPublish(grantee)` (PutObject) and `GrantLargePayloadConsume(grantee)` (Get/Delete)
+- CDK tests covering synthesis outputs and IAM policies.
+
+**Acceptance Criteria**
+- Synthesized template contains `AWS::S3::Bucket` with a lifecycle expiration rule when `LargePayload` is enabled.
+- Synthesized template shows the Lambda role has:
+  - `s3:GetObject` and `s3:DeleteObject` permissions scoped to the bucket + prefix
+- No new “tuning” env vars are required by the consumer for hydration (consumer can hydrate based solely on the pointer envelope).
+
+---
+
+### Milestone 3 — Runtime: S3 Offload + Hydration + Delete Helpers
+
+**Deliverables**
+- Add a Lift runtime helper package (proposed location: `pkg/services/sqs_large_payload`) implementing:
+  - Encode/decode pointer envelopes
+  - S3 `PutObject` for offload (no gzip)
+  - S3 `GetObject` for hydration
+  - S3 `DeleteObject` on success
+- Add a small in-memory/mockable interface to unit test without AWS.
+- Add unit tests for:
+  - offload decision at `>256KB`
+  - envelope parse/validation
+  - hydrate replaces message body correctly
+  - delete called only when appropriate
+
+**Acceptance Criteria**
+- Helpers can:
+  - offload and return a pointer envelope
+  - hydrate a pointer envelope into original bytes
+  - delete the referenced object
+- Unit tests cover threshold and envelope validation.
+- No gzip/compression code paths exist.
+
+---
+
+### Milestone 4 — Lift Core: First-Class SQS Batch Responses
+
+**Deliverables**
+- Update Lift request handling so SQS-triggered handlers can return `events.SQSBatchResponse` (raw) when `ReportBatchItemFailures` is enabled.
+- Add tests ensuring:
+  - SQS returns raw batch response (not wrapped in API Gateway proxy response)
+  - existing HTTP/APIGW behavior is unchanged
+
+**Acceptance Criteria**
+- A handler registered via `app.SQS(...)` can return `events.SQSBatchResponse`, and the Lambda result is exactly the batch response object.
+- Partial failures work end-to-end in tests (successful messages are not re-driven).
+
+---
+
+### Milestone 5 — “Batteries Included” SQS Large Payload Handler Helper
+
+**Deliverables**
+- Provide a helper (or middleware) that standardizes the pattern:
+  - iterate records
+  - hydrate per-message if pointer envelope
+  - call a per-message user handler
+  - build `BatchItemFailures` for failures only
+  - delete S3 objects for successes only
+- Include hooks for logging/metrics and a clear error taxonomy:
+  - hydrate failure
+  - handler failure
+  - delete failure (non-fatal; TTL fallback)
+
+**Acceptance Criteria**
+- Helper supports mixed batches (some pointer messages, some inline messages).
+- On mixed success/failure batches:
+  - only successful messages’ S3 payloads are deleted
+  - failed messages are returned in `BatchItemFailures`
+- Delete failures do not incorrectly mark the message as failed (unless explicitly configured).
+
+---
+
+### Milestone 6 — Documentation + Examples
+
+**Deliverables**
+- New doc page describing the pattern and how to enable it via `SQSProcessorProps.LargePayload`.
+- Add a working example demonstrating:
+  - a producer that offloads large payloads to S3 and sends pointers to SQS
+  - a consumer using Lift + the helper to hydrate and delete-on-success
+- Update CDK/API references as needed.
+
+**Acceptance Criteria**
+- Example compiles and demonstrates:
+  - payload `>256KB` offloads to S3
+  - SQS receives pointer envelope
+  - consumer hydrates payload and deletes the S3 object on success
+  - partial failures do not delete failed messages’ payloads
+
+## Risks & Mitigations
+
+- **S3 object leaks** (delete fails): mitigate with lifecycle TTL + logging/metrics for delete failures.
+- **Duplicate delivery** (SQS at-least-once): helper should be idempotency-friendly; deleting a missing object should be treated as success.
+- **Security**: enforce least-privilege IAM (prefix-scoped), block public access, and avoid embedding sensitive data in the pointer envelope beyond bucket/key.
+
+## Open Questions
+
+- Default TTL duration: should it mirror queue retention (14 days), or a shorter TTL (e.g., 7 days)?
+- Should the helper support optional integrity verification (`sha256`) by default or only when provided?
+- Should Lift add a small “publisher binding” helper on `SQSProcessor` to simplify wiring producers (grant + optional convenience env injection)?
+

--- a/docs/planning/sqs-large-payload-s3.md
+++ b/docs/planning/sqs-large-payload-s3.md
@@ -202,6 +202,9 @@ Notes:
 ## Open Questions
 
 - Default TTL duration: should it mirror queue retention (14 days), or a shorter TTL (e.g., 7 days)?
+ANSWER: 7 days.
 - Should the helper support optional integrity verification (`sha256`) by default or only when provided?
+ANSWER: By default verify integrity, but allow disabling it.
 - Should Lift add a small “publisher binding” helper on `SQSProcessor` to simplify wiring producers (grant + optional convenience env injection)?
+ANSWER: Yes.
 

--- a/docs/planning/sqs-large-payload-s3.md
+++ b/docs/planning/sqs-large-payload-s3.md
@@ -143,13 +143,13 @@ Notes:
 ### Milestone 4 — Lift Core: First-Class SQS Batch Responses
 
 **Deliverables**
-- Update Lift request handling so SQS-triggered handlers can return `events.SQSBatchResponse` (raw) when `ReportBatchItemFailures` is enabled.
+- Update Lift request handling so SQS-triggered handlers can return `events.SQSEventResponse` (raw) when `ReportBatchItemFailures` is enabled.
 - Add tests ensuring:
   - SQS returns raw batch response (not wrapped in API Gateway proxy response)
   - existing HTTP/APIGW behavior is unchanged
 
 **Acceptance Criteria**
-- A handler registered via `app.SQS(...)` can return `events.SQSBatchResponse`, and the Lambda result is exactly the batch response object.
+- A handler registered via `app.SQS(...)` can return `events.SQSEventResponse`, and the Lambda result is exactly the batch response object.
 - Partial failures work end-to-end in tests (successful messages are not re-driven).
 
 ---
@@ -207,4 +207,3 @@ ANSWER: 7 days.
 ANSWER: By default verify integrity, but allow disabling it.
 - Should Lift add a small “publisher binding” helper on `SQSProcessor` to simplify wiring producers (grant + optional convenience env injection)?
 ANSWER: Yes.
-

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ This directory contains working examples demonstrating various features and patt
 - **[websocket-demo](./websocket-demo/)** - WebSocket support with connection management
 - **[websocket-enhanced](./websocket-enhanced/)** - Advanced WebSocket implementation
 - **[event-adapters](./event-adapters/)** - Multiple AWS event source handlers (SQS, S3, EventBridge)
+- **[sqs-large-payload](./sqs-large-payload/)** - SQS payloads >256KB offloaded to S3 (pointer envelope + delete-on-success)
 - **[multi-event-handler](./multi-event-handler/)** - Handling multiple event types
 - **[eventbridge-wakeup](./eventbridge-wakeup/)** - EventBridge scheduled events
 - **[multiple-scheduled-events](./multiple-scheduled-events/)** - Multiple scheduled Lambda triggers

--- a/examples/sqs-large-payload/README.md
+++ b/examples/sqs-large-payload/README.md
@@ -1,0 +1,26 @@
+# SQS Large Payloads via S3 (Example)
+
+Demonstrates Lift’s “extended SQS payload” pattern:
+
+- Producer offloads payloads **> 256KB** to an object store (S3 in production)
+- Producer sends a small pointer envelope through SQS
+- Consumer hydrates the payload from the object store and **deletes it on success**
+- Partial failures return `BatchItemFailures` and do **not** delete failed messages’ objects
+
+This example runs locally using an in-memory `ObjectStore` implementation (no AWS required).
+
+## Run
+
+```bash
+go run ./examples/sqs-large-payload
+```
+
+## What To Look For
+
+- The “large” messages are offloaded and the SQS body becomes an envelope (`type: lift:sqs-large-payload:v1`).
+- The consumer processes a mixed batch:
+  - one offloaded message succeeds → object is deleted
+  - one offloaded message fails → object remains (TTL would be the fallback in production)
+  - one inline message succeeds → no object exists
+- The printed `BatchItemFailures` contains only the failed message ID.
+

--- a/examples/sqs-large-payload/main.go
+++ b/examples/sqs-large-payload/main.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/pay-theory/lift/pkg/lift"
+	sqslargepayload "github.com/pay-theory/lift/pkg/services/sqs_large_payload"
+)
+
+type job struct {
+	ID   string `json:"id"`
+	Data string `json:"data"`
+}
+
+type memoryStore struct {
+	objects map[sqslargepayload.Ref][]byte
+}
+
+func newMemoryStore() *memoryStore {
+	return &memoryStore{objects: make(map[sqslargepayload.Ref][]byte)}
+}
+
+func (s *memoryStore) Put(_ context.Context, ref sqslargepayload.Ref, payload []byte) error {
+	if ref.Bucket == "" || ref.Key == "" {
+		return errors.New("memory store ref must include bucket and key")
+	}
+	if payload == nil {
+		payload = []byte{}
+	}
+	cp := make([]byte, len(payload))
+	copy(cp, payload)
+	s.objects[ref] = cp
+	return nil
+}
+
+func (s *memoryStore) Get(_ context.Context, ref sqslargepayload.Ref) ([]byte, error) {
+	payload, ok := s.objects[ref]
+	if !ok {
+		return nil, errors.New("memory store object not found")
+	}
+	cp := make([]byte, len(payload))
+	copy(cp, payload)
+	return cp, nil
+}
+
+func (s *memoryStore) Delete(_ context.Context, ref sqslargepayload.Ref) error {
+	// Mirror S3 semantics: deleting a missing object is not an error.
+	delete(s.objects, ref)
+	return nil
+}
+
+func (s *memoryStore) keys() []string {
+	out := make([]string, 0, len(s.objects))
+	for ref := range s.objects {
+		out = append(out, fmt.Sprintf("%s/%s", ref.Bucket, ref.Key))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func produce(ctx context.Context, store sqslargepayload.ObjectStore, bucket, prefix, messageID string, payload []byte) (events.SQSMessage, error) {
+	key := fmt.Sprintf("%s%s.json", prefix, messageID)
+
+	body, envelope, err := sqslargepayload.OffloadIfNeeded(
+		ctx,
+		store,
+		sqslargepayload.Ref{Bucket: bucket, Key: key},
+		payload,
+		sqslargepayload.DefaultOptions(),
+	)
+	if err != nil {
+		return events.SQSMessage{}, err
+	}
+
+	if envelope != nil {
+		fmt.Printf("producer: offloaded messageId=%s bytes=%d -> s3://%s/%s\n", messageID, len(payload), envelope.Bucket, envelope.Key)
+		fmt.Printf("producer: sqs body is envelope type=%s\n", envelope.Type)
+	} else {
+		fmt.Printf("producer: inline messageId=%s bytes=%d\n", messageID, len(payload))
+	}
+
+	return events.SQSMessage{
+		MessageId: messageID,
+		Body:      string(body),
+	}, nil
+}
+
+func main() {
+	ctx := context.Background()
+
+	const (
+		bucket = "example-bucket"
+		prefix = "sqs/example-queue/messages/"
+	)
+
+	store := newMemoryStore()
+
+	largeOKPayload, _ := json.Marshal(job{
+		ID:   "large-ok",
+		Data: strings.Repeat("x", sqslargepayload.SQSMaxMessageBytes+1024),
+	})
+	largeFailPayload, _ := json.Marshal(job{
+		ID:   "large-fail",
+		Data: strings.Repeat("y", sqslargepayload.SQSMaxMessageBytes+2048),
+	})
+	smallOKPayload, _ := json.Marshal(job{
+		ID:   "small-ok",
+		Data: "hello",
+	})
+
+	largeOK, err := produce(ctx, store, bucket, prefix, "msg-1", largeOKPayload)
+	if err != nil {
+		panic(err)
+	}
+	largeFail, err := produce(ctx, store, bucket, prefix, "msg-2", largeFailPayload)
+	if err != nil {
+		panic(err)
+	}
+	smallOK, err := produce(ctx, store, bucket, prefix, "msg-3", smallOKPayload)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("store: objects after produce: %v\n", store.keys())
+
+	app := lift.New()
+
+	processor := sqslargepayload.BatchProcessor{
+		Store:   store,
+		Options: sqslargepayload.DefaultOptions(),
+		Hooks: sqslargepayload.BatchHooks{
+			OnFailure: func(_ context.Context, failure sqslargepayload.Failure) {
+				fmt.Printf("consumer: failure kind=%s messageId=%s err=%v\n", failure.Kind, failure.Message.Record.MessageId, failure.Err)
+			},
+		},
+	}
+
+	if err := app.SQS("*", func(ctx *lift.Context) (any, error) {
+		records, err := ctx.SQSRecords()
+		if err != nil {
+			return events.SQSEventResponse{}, err
+		}
+
+		return processor.Process(ctx, records, func(_ context.Context, msg sqslargepayload.Message) error {
+			var j job
+			if err := json.Unmarshal(msg.Payload, &j); err != nil {
+				return err
+			}
+
+			fmt.Printf(
+				"consumer: handle id=%s messageId=%s offloaded=%t payloadBytes=%d\n",
+				j.ID,
+				msg.Record.MessageId,
+				msg.Envelope != nil,
+				len(msg.Payload),
+			)
+
+			if j.ID == "large-fail" {
+				return errors.New("simulated handler error")
+			}
+			return nil
+		})
+	}); err != nil {
+		panic(err)
+	}
+
+	event := map[string]any{
+		"Records": []any{
+			sqsRecord(largeOK, "rh-1"),
+			sqsRecord(largeFail, "rh-2"),
+			sqsRecord(smallOK, "rh-3"),
+		},
+	}
+
+	result, err := app.HandleRequest(ctx, event)
+	if err != nil {
+		panic(err)
+	}
+
+	resp, ok := result.(events.SQSEventResponse)
+	if !ok {
+		panic(fmt.Errorf("expected events.SQSEventResponse, got %T", result))
+	}
+
+	fmt.Printf("consumer: batch item failures: %+v\n", resp.BatchItemFailures)
+	fmt.Printf("store: objects after consume: %v\n", store.keys())
+}
+
+func sqsRecord(msg events.SQSMessage, receiptHandle string) map[string]any {
+	return map[string]any{
+		"messageId":      msg.MessageId,
+		"body":           msg.Body,
+		"receiptHandle":  receiptHandle,
+		"eventSource":    "aws:sqs",
+		"eventSourceARN": "arn:aws:sqs:us-east-1:123456789012:example-queue",
+		"awsRegion":      "us-east-1",
+		"attributes": map[string]any{
+			"SentTimestamp": "0",
+		},
+	}
+}

--- a/pkg/cdk/constructs/sqs_processor.go
+++ b/pkg/cdk/constructs/sqs_processor.go
@@ -12,6 +12,8 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2/awssqs"
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/aws/jsii-runtime-go"
+
+	"github.com/pay-theory/lift/pkg/naming"
 )
 
 const (
@@ -101,6 +103,12 @@ type SQSProcessor struct {
 
 	// Event source mapping
 	EventSource awslambdaeventsources.SqsEventSource
+
+	// LargePayloadBucket stores oversized SQS message bodies (optional).
+	LargePayloadBucket awss3.IBucket
+
+	// LargePayloadPrefix scopes object keys + IAM permissions (optional).
+	LargePayloadPrefix *string
 }
 
 // NewSQSProcessor creates a new SQS processor construct
@@ -196,6 +204,9 @@ func (b *sqsProcessorBuilder) build() *SQSProcessor {
 	// Create or use existing queue
 	b.setupQueue()
 
+	// Configure large payload storage if enabled
+	b.setupLargePayload()
+
 	// Create Lambda function
 	b.setupFunction()
 
@@ -240,6 +251,12 @@ func (b *sqsProcessorBuilder) setupPermissions() {
 	if b.processor.DeadLetterQueue != nil {
 		b.processor.DeadLetterQueue.GrantSendMessages(b.processor.Function.Function)
 	}
+
+	if b.processor.LargePayloadBucket != nil && b.processor.LargePayloadPrefix != nil {
+		pattern := jsii.String(*b.processor.LargePayloadPrefix + "*")
+		b.processor.LargePayloadBucket.GrantRead(b.processor.Function.Function, pattern)
+		b.processor.LargePayloadBucket.GrantDelete(b.processor.Function.Function, pattern)
+	}
 }
 
 // setupMonitoring adds monitoring if enabled
@@ -247,6 +264,149 @@ func (b *sqsProcessorBuilder) setupMonitoring() {
 	if b.props.EnableMonitoring != nil && *b.props.EnableMonitoring {
 		b.processor.enableMonitoring()
 	}
+}
+
+func (b *sqsProcessorBuilder) setupLargePayload() {
+	if b.props == nil || b.props.LargePayload == nil {
+		return
+	}
+
+	enabled := true
+	if b.props.LargePayload.Enabled != nil {
+		enabled = *b.props.LargePayload.Enabled
+	}
+	if !enabled {
+		return
+	}
+
+	prefix := b.props.LargePayload.Prefix
+	if prefix == nil {
+		queueName := b.deriveLargePayloadQueueName()
+		if queueName != "" {
+			prefix = jsii.String(fmt.Sprintf("sqs/%s/messages/", queueName))
+		} else {
+			derived := b.processor.Queue.QueueName()
+			if derived != nil && *derived != "" {
+				prefix = jsii.String(fmt.Sprintf("sqs/%s/messages/", *derived))
+			} else {
+				prefix = jsii.String("sqs/messages/")
+			}
+		}
+	}
+
+	b.processor.LargePayloadPrefix = prefix
+	b.processor.LargePayloadBucket = b.resolveLargePayloadBucket(prefix)
+}
+
+func (b *sqsProcessorBuilder) deriveLargePayloadQueueName() string {
+	if b.props == nil {
+		return ""
+	}
+	if b.props.ExistingQueue != nil {
+		return ""
+	}
+
+	if b.props.QueueProps != nil && b.props.QueueProps.QueueName != nil && *b.props.QueueProps.QueueName != "" {
+		queueName := *b.props.QueueProps.QueueName
+		if b.config != nil && b.config.fifoQueue {
+			queueName = ensureFifoSuffix(queueName)
+		}
+		return queueName
+	}
+
+	if b.props.FunctionProps.FunctionName != nil && *b.props.FunctionProps.FunctionName != "" {
+		suffix := ""
+		if b.config != nil && b.config.fifoQueue {
+			suffix = fifoSuffix
+		}
+		return *b.props.FunctionProps.FunctionName + "-queue" + suffix
+	}
+
+	return ""
+}
+
+func ensureFifoSuffix(queueName string) string {
+	if len(queueName) < len(fifoSuffix) || queueName[len(queueName)-len(fifoSuffix):] != fifoSuffix {
+		return queueName + fifoSuffix
+	}
+	return queueName
+}
+
+func (b *sqsProcessorBuilder) resolveLargePayloadBucket(prefix *string) awss3.IBucket {
+	if b.props == nil || b.props.LargePayload == nil {
+		return nil
+	}
+	if b.props.LargePayload.ExistingBucket != nil {
+		return b.props.LargePayload.ExistingBucket
+	}
+
+	// When callers don't provide a bucket, create a shared default bucket once per stack.
+	if b.props.LargePayload.BucketProps == nil {
+		stack := awscdk.Stack_Of(b.processor)
+		if stack != nil {
+			if existing := stack.Node().TryFindChild(jsii.String("SQSLargePayloadBucket")); existing != nil {
+				if bucket, ok := existing.(awss3.Bucket); ok {
+					return bucket
+				}
+			}
+		}
+	}
+
+	bucketProps := &awss3.BucketProps{
+		BlockPublicAccess: awss3.BlockPublicAccess_BLOCK_ALL(),
+		Encryption:        awss3.BucketEncryption_S3_MANAGED,
+		EnforceSSL:        jsii.Bool(true),
+	}
+	if b.props.LargePayload.BucketProps != nil {
+		applyNonNilStructFields(bucketProps, b.props.LargePayload.BucketProps)
+	}
+
+	if bucketProps.BucketName == nil {
+		if resolved, ok := naming.S3BucketNameFromEnv("sqs-large-payload"); ok {
+			bucketProps.BucketName = jsii.String(resolved)
+		}
+	}
+
+	expiration := b.props.LargePayload.Expiration
+	if expiration == nil {
+		expiration = awscdk.Duration_Days(jsii.Number(7))
+	}
+
+	lifecyclePrefix := prefix
+	if b.props.LargePayload.BucketProps == nil {
+		lifecyclePrefix = nil
+	}
+	ensureLargePayloadLifecycle(bucketProps, lifecyclePrefix, expiration)
+
+	// Default bucket goes at the stack scope (stable ID) so multiple processors can reuse it.
+	if b.props.LargePayload.BucketProps == nil {
+		stack := awscdk.Stack_Of(b.processor)
+		if stack != nil {
+			return awss3.NewBucket(stack, jsii.String("SQSLargePayloadBucket"), bucketProps)
+		}
+	}
+
+	return awss3.NewBucket(b.processor, jsii.String("LargePayloadBucket"), bucketProps)
+}
+
+func ensureLargePayloadLifecycle(bucketProps *awss3.BucketProps, prefix *string, expiration awscdk.Duration) {
+	if bucketProps == nil || expiration == nil {
+		return
+	}
+
+	rule := &awss3.LifecycleRule{
+		Id:         jsii.String("ExpireLargePayloadObjects"),
+		Enabled:    jsii.Bool(true),
+		Expiration: expiration,
+		Prefix:     prefix,
+	}
+
+	if bucketProps.LifecycleRules == nil {
+		bucketProps.LifecycleRules = &[]*awss3.LifecycleRule{rule}
+		return
+	}
+
+	*bucketProps.LifecycleRules = append(*bucketProps.LifecycleRules, rule)
 }
 
 // sqsQueueBuilder builds SQS queue components
@@ -671,6 +831,24 @@ func (s *SQSProcessor) GrantSendMessages(grantee awslambda.IFunction) {
 // GrantConsumeMessages grants permission to consume messages from the queue
 func (s *SQSProcessor) GrantConsumeMessages(grantee awslambda.IFunction) {
 	s.Queue.GrantConsumeMessages(grantee)
+}
+
+// GrantLargePayloadPublish grants permission to write large payload objects to the payload bucket.
+func (s *SQSProcessor) GrantLargePayloadPublish(grantee awslambda.IFunction) {
+	if s.LargePayloadBucket == nil || s.LargePayloadPrefix == nil {
+		return
+	}
+	s.LargePayloadBucket.GrantWrite(grantee, jsii.String(*s.LargePayloadPrefix+"*"), nil)
+}
+
+// GrantLargePayloadConsume grants permission to read and delete large payload objects from the payload bucket.
+func (s *SQSProcessor) GrantLargePayloadConsume(grantee awslambda.IFunction) {
+	if s.LargePayloadBucket == nil || s.LargePayloadPrefix == nil {
+		return
+	}
+	pattern := jsii.String(*s.LargePayloadPrefix + "*")
+	s.LargePayloadBucket.GrantRead(grantee, pattern)
+	s.LargePayloadBucket.GrantDelete(grantee, pattern)
 }
 
 // AddEnvironmentVariable adds an environment variable to the Lambda function

--- a/pkg/cdk/constructs/sqs_processor.go
+++ b/pkg/cdk/constructs/sqs_processor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2/awscloudwatch"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslambdaeventsources"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awss3"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awssns"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awssqs"
 	"github.com/aws/constructs-go/constructs/v10"
@@ -51,6 +52,38 @@ type SQSProcessorProps struct {
 	EnableTracing     *bool
 	EnableMultiTenant *bool
 	EnableMonitoring  *bool
+
+	// Large payload support (optional).
+	//
+	// When enabled, Lift provisions (or attaches) an S3 bucket that can store
+	// payloads larger than SQS's 256KB limit. Producers publish a small pointer
+	// envelope to SQS containing the S3 bucket + key. Consumers hydrate the full
+	// payload from S3 and delete it on success (with lifecycle TTL as a fallback).
+	LargePayload *SQSLargePayloadProps
+}
+
+// SQSLargePayloadProps configures S3-backed "extended payloads" for an SQSProcessor.
+type SQSLargePayloadProps struct {
+	// Enabled toggles large payload support. When nil, defaults to true when
+	// LargePayload is provided.
+	Enabled *bool
+
+	// ExistingBucket uses an existing bucket for payload storage (optional).
+	// When provided, BucketProps is ignored.
+	ExistingBucket awss3.IBucket
+
+	// BucketProps creates a new bucket for payload storage when ExistingBucket is nil.
+	// If BucketProps.BucketName is omitted, Lift will derive a deterministic name
+	// when stable naming context is available (see milestone 2).
+	BucketProps *awss3.BucketProps
+
+	// Prefix scopes object storage to a per-queue prefix within the bucket.
+	// If omitted, Lift derives a prefix from the queue name (see milestone 2).
+	Prefix *string
+
+	// Expiration is the S3 lifecycle expiration for payload objects (TTL fallback).
+	// When nil, defaults to 7 days.
+	Expiration awscdk.Duration
 }
 
 // SQSProcessor represents an SQS queue with Lambda processor

--- a/pkg/cdk/constructs/sqs_processor_test.go
+++ b/pkg/cdk/constructs/sqs_processor_test.go
@@ -1,6 +1,7 @@
 package constructs
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2"
@@ -329,4 +330,167 @@ func TestSQSProcessor_CustomEventSourceProps(t *testing.T) {
 
 	// Verify custom event source configuration
 	assertResourceExists(t, template, "AWS::Lambda::EventSourceMapping")
+}
+
+func TestSQSProcessor_LargePayload_DefaultBucketLifecycleAndPermissions(t *testing.T) {
+	app := awscdk.NewApp(nil)
+	stack := awscdk.NewStack(app, jsii.String("TestStack"), nil)
+
+	processor := NewSQSProcessor(stack, jsii.String("TestSQSProcessor"), &SQSProcessorProps{
+		FunctionProps: awslambda.FunctionProps{
+			FunctionName: jsii.String("large-payload-processor"),
+			Code:         awslambda.Code_FromInline(jsii.String("exports.handler = async () => {}")),
+			Handler:      jsii.String("index.handler"),
+			Runtime:      awslambda.Runtime_NODEJS_18_X(),
+		},
+		QueueProps: &awssqs.QueueProps{
+			QueueName: jsii.String("large-payload-queue"),
+		},
+		LargePayload: &SQSLargePayloadProps{},
+	})
+
+	if processor == nil {
+		t.Fatal("Processor should be created")
+	}
+	if processor.LargePayloadBucket == nil {
+		t.Fatal("Large payload bucket should be created")
+	}
+	if processor.LargePayloadPrefix == nil {
+		t.Fatal("Large payload prefix should be set")
+	}
+	if got, want := *processor.LargePayloadPrefix, "sqs/large-payload-queue/messages/"; got != want {
+		t.Fatalf("Large payload prefix should be derived, got %q want %q", got, want)
+	}
+
+	template := synthesizeTemplate(t, stack)
+
+	// Verify S3 bucket exists
+	assertResourceCount(t, template, "AWS::S3::Bucket", 1)
+
+	// Verify bucket lifecycle configuration includes default expiration
+	buckets := findResourcesByType(template, "AWS::S3::Bucket")
+	for _, bucket := range buckets {
+		props, ok := bucket["Properties"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Bucket should have Properties")
+		}
+
+		lifecycle, ok := props["LifecycleConfiguration"].(map[string]interface{})
+		if !ok {
+			t.Fatal("Bucket should have LifecycleConfiguration")
+		}
+
+		rules, ok := lifecycle["Rules"].([]interface{})
+		if !ok || len(rules) == 0 {
+			t.Fatal("Bucket should have at least one lifecycle rule")
+		}
+
+		foundExpiration := false
+		for _, rule := range rules {
+			ruleMap, ok := rule.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			if ruleMap["Id"] != "ExpireLargePayloadObjects" {
+				continue
+			}
+
+			if ruleMap["Status"] != "Enabled" {
+				t.Fatalf("Expected lifecycle rule to be enabled, got %v", ruleMap["Status"])
+			}
+
+			if exp, ok := ruleMap["ExpirationInDays"].(float64); !ok || int(exp) != 7 {
+				t.Fatalf("Expected lifecycle rule expiration 7 days, got %v", ruleMap["ExpirationInDays"])
+			}
+
+			foundExpiration = true
+		}
+
+		if !foundExpiration {
+			t.Fatal("Expected to find lifecycle rule ExpireLargePayloadObjects with 7 day expiration")
+		}
+	}
+
+	// Verify IAM policies include s3:GetObject and s3:DeleteObject scoped to the prefix.
+	expectedKeySuffix := "sqs/large-payload-queue/messages/*"
+	policies := findResourcesByType(template, "AWS::IAM::Policy")
+	if len(policies) == 0 {
+		t.Fatal("Expected IAM policies to exist")
+	}
+
+	hasGet := false
+	hasDelete := false
+
+	for _, policy := range policies {
+		props, ok := policy["Properties"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		doc, ok := props["PolicyDocument"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		statements, ok := doc["Statement"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, statement := range statements {
+			stmt, ok := statement.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			action := stmt["Action"]
+			resource := stmt["Resource"]
+
+			if actionHasPrefix(action, "s3:GetObject") && containsString(resource, expectedKeySuffix) {
+				hasGet = true
+			}
+			if actionHasPrefix(action, "s3:DeleteObject") && containsString(resource, expectedKeySuffix) {
+				hasDelete = true
+			}
+		}
+	}
+
+	if !hasGet {
+		t.Fatalf("Expected IAM policy to grant s3:GetObject on %q", expectedKeySuffix)
+	}
+	if !hasDelete {
+		t.Fatalf("Expected IAM policy to grant s3:DeleteObject on %q", expectedKeySuffix)
+	}
+}
+
+func actionHasPrefix(action interface{}, prefix string) bool {
+	switch a := action.(type) {
+	case string:
+		return strings.HasPrefix(a, prefix)
+	case []interface{}:
+		for _, entry := range a {
+			if actionHasPrefix(entry, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func containsString(value interface{}, needle string) bool {
+	switch v := value.(type) {
+	case string:
+		return strings.Contains(v, needle)
+	case []interface{}:
+		for _, entry := range v {
+			if containsString(entry, needle) {
+				return true
+			}
+		}
+	case map[string]interface{}:
+		for _, entry := range v {
+			if containsString(entry, needle) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/lift/app.go
+++ b/pkg/lift/app.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-lambda-go/events"
 	"github.com/pay-theory/lift/pkg/lift/adapters"
 )
 
@@ -734,6 +735,15 @@ func (b *requestHandlerBuilder) build() (any, error) {
 		return b.liftCtx.Response.Body, nil
 	}
 
+	// SQS batch processors expect the raw batch response (e.g. BatchItemFailures),
+	// not an API Gateway proxy response wrapper, when ReportBatchItemFailures is enabled.
+	if b.request.TriggerType == adapters.TriggerSQS {
+		switch b.liftCtx.Response.Body.(type) {
+		case events.SQSEventResponse, *events.SQSEventResponse:
+			return b.liftCtx.Response.Body, nil
+		}
+	}
+
 	return b.liftCtx.Response, nil
 }
 
@@ -1263,6 +1273,10 @@ func (a *App) handleError(ctx *Context, err error) (any, error) {
 	// DynamoDB stream processors should generally surface errors so Lambda retries (or sends to DLQ).
 	// EventBus handlers use BatchItemFailures to avoid returning errors for per-record failures.
 	if ctx != nil && ctx.Request != nil && ctx.Request.TriggerType == adapters.TriggerEventBus {
+		return nil, err
+	}
+	// SQS handlers should surface errors so Lambda retries the batch (or sends to DLQ).
+	if ctx != nil && ctx.Request != nil && ctx.Request.TriggerType == adapters.TriggerSQS {
 		return nil, err
 	}
 	if a.isAppSyncRequest(ctx) {

--- a/pkg/lift/app.go
+++ b/pkg/lift/app.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-lambda-go/events"
+
 	"github.com/pay-theory/lift/pkg/lift/adapters"
 )
 

--- a/pkg/lift/app_sqs_batch_response_test.go
+++ b/pkg/lift/app_sqs_batch_response_test.go
@@ -1,0 +1,91 @@
+package lift_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/pay-theory/lift/pkg/lift"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApp_SQS_ReturnsBatchResponseRaw(t *testing.T) {
+	app := lift.New()
+
+	require.NoError(t, app.SQS("*", func(_ *lift.Context) (any, error) {
+		return events.SQSEventResponse{
+			BatchItemFailures: []events.SQSBatchItemFailure{
+				{ItemIdentifier: "msg-1"},
+			},
+		}, nil
+	}))
+
+	respAny, err := app.HandleRequest(context.Background(), map[string]any{
+		"Records": []any{
+			map[string]any{
+				"messageId":      "msg-1",
+				"receiptHandle":  "rh-1",
+				"body":           "hello",
+				"eventSource":    "aws:sqs",
+				"eventSourceARN": "arn:aws:sqs:us-east-1:123456789012:test-queue",
+				"attributes": map[string]any{
+					"SentTimestamp": "1700000000",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	batchResp, ok := respAny.(events.SQSEventResponse)
+	require.True(t, ok, "expected events.SQSEventResponse, got %T", respAny)
+	require.Len(t, batchResp.BatchItemFailures, 1)
+	require.Equal(t, "msg-1", batchResp.BatchItemFailures[0].ItemIdentifier)
+}
+
+func TestApp_SQS_PropagatesHandlerErrors(t *testing.T) {
+	app := lift.New()
+
+	require.NoError(t, app.SQS("*", func(_ *lift.Context) error {
+		return errors.New("boom")
+	}))
+
+	respAny, err := app.HandleRequest(context.Background(), map[string]any{
+		"Records": []any{
+			map[string]any{
+				"messageId":     "msg-1",
+				"receiptHandle": "rh-1",
+				"body":          "hello",
+				"eventSource":   "aws:sqs",
+			},
+		},
+	})
+	require.Error(t, err)
+	require.Nil(t, respAny)
+}
+
+func TestApp_HTTP_StillReturnsProxyResponse(t *testing.T) {
+	app := lift.New()
+
+	require.NoError(t, app.GET("/ok", func(ctx *lift.Context) error {
+		return ctx.JSON(map[string]string{"status": "ok"})
+	}))
+
+	respAny, err := app.HandleRequest(context.Background(), map[string]any{
+		"version":  "2.0",
+		"routeKey": "GET /ok",
+		"rawPath":  "/ok",
+		"requestContext": map[string]any{
+			"http": map[string]any{
+				"method": "GET",
+				"path":   "/ok",
+			},
+		},
+		"headers":         map[string]any{},
+		"isBase64Encoded": false,
+	})
+	require.NoError(t, err)
+
+	_, ok := respAny.(*lift.Response)
+	require.True(t, ok, "expected *lift.Response, got %T", respAny)
+}

--- a/pkg/services/sqs_large_payload/batch.go
+++ b/pkg/services/sqs_large_payload/batch.go
@@ -20,10 +20,10 @@ const (
 
 // Failure describes an error encountered while processing an individual SQS message.
 type Failure struct {
-	Kind     FailureKind
-	Message  Message
 	Envelope *Envelope
 	Err      error
+	Kind     FailureKind
+	Message  Message
 }
 
 func (f Failure) Error() string {
@@ -49,9 +49,9 @@ type BatchHooks struct {
 // Message is the per-record context passed to the user handler.
 type Message struct {
 	Record   events.SQSMessage
+	Envelope *Envelope
 	RawBody  []byte
 	Payload  []byte
-	Envelope *Envelope
 }
 
 // MessageHandler processes an individual message (inline or hydrated).
@@ -67,9 +67,9 @@ type MessageHandler func(ctx context.Context, message Message) error
 //   - Return an events.SQSEventResponse containing only the failed message IDs.
 type BatchProcessor struct {
 	Store             ObjectStore
+	Hooks             BatchHooks
 	Options           Options
 	FailOnDeleteError bool
-	Hooks             BatchHooks
 }
 
 // Process handles a batch of SQS messages and returns an SQS batch response suitable for
@@ -85,7 +85,8 @@ func (p BatchProcessor) Process(ctx context.Context, records []events.SQSMessage
 	failures := make([]events.SQSBatchItemFailure, 0)
 
 	for _, record := range records {
-		if record.MessageId == "" {
+		messageID := record.MessageId
+		if messageID == "" {
 			return events.SQSEventResponse{}, errors.New("sqs message missing messageId")
 		}
 
@@ -96,55 +97,41 @@ func (p BatchProcessor) Process(ctx context.Context, records []events.SQSMessage
 			RawBody: rawBody,
 		}
 
-		envelope, isEnvelope, err := parseLiftEnvelope(rawBody)
-		extendedPointer, isExtendedPointer, extErr := ParseSQSExtendedClientPointer(rawBody)
+		pointer, err := parseOffloadPointer(rawBody)
+		if err != nil {
+			failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: messageID})
+			p.emitFailure(ctx, Failure{Kind: FailureHydrate, Message: message, Envelope: pointer.envelope, Err: err})
+			continue
+		}
 
-		if isEnvelope || isExtendedPointer {
-			if isEnvelope {
-				message.Envelope = envelope
-			}
-
-			if err != nil || extErr != nil {
-				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
-				if err != nil {
-					p.emitFailure(ctx, Failure{Kind: FailureHydrate, Message: message, Envelope: envelope, Err: err})
-				} else {
-					p.emitFailure(ctx, Failure{Kind: FailureHydrate, Message: message, Envelope: nil, Err: extErr})
-				}
-				continue
-			}
-
+		if pointer.kind == offloadPointerNone {
+			message.Payload = rawBody
+		} else {
 			if p.Store == nil {
-				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
+				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: messageID})
 				p.emitFailure(ctx, Failure{
 					Kind:     FailureHydrate,
 					Message:  message,
-					Envelope: envelope,
+					Envelope: pointer.envelope,
 					Err:      errors.New("sqs large payload store is nil"),
 				})
 				continue
 			}
 
-			var payload []byte
-			if isEnvelope {
-				payload, err = Hydrate(ctx, p.Store, *envelope, p.Options)
-			} else {
-				payload, err = p.Store.Get(ctx, extendedPointer.Ref())
-			}
-
+			payload, err := p.hydratePointer(ctx, pointer)
 			if err != nil {
-				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
-				p.emitFailure(ctx, Failure{Kind: FailureHydrate, Message: message, Envelope: envelope, Err: err})
+				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: messageID})
+				p.emitFailure(ctx, Failure{Kind: FailureHydrate, Message: message, Envelope: pointer.envelope, Err: err})
 				continue
 			}
+
 			message.Payload = payload
-		} else {
-			message.Payload = rawBody
+			message.Envelope = pointer.envelope
 		}
 
 		if err := handler(ctx, message); err != nil {
-			failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
-			p.emitFailure(ctx, Failure{Kind: FailureHandler, Message: message, Envelope: envelope, Err: err})
+			failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: messageID})
+			p.emitFailure(ctx, Failure{Kind: FailureHandler, Message: message, Envelope: pointer.envelope, Err: err})
 			continue
 		}
 
@@ -152,27 +139,54 @@ func (p BatchProcessor) Process(ctx context.Context, records []events.SQSMessage
 			continue
 		}
 
-		if isEnvelope && envelope != nil {
-			if err := Delete(ctx, p.Store, *envelope); err != nil {
-				p.emitFailure(ctx, Failure{Kind: FailureDelete, Message: message, Envelope: envelope, Err: err})
-				if p.FailOnDeleteError {
-					failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
-				}
-			}
-			continue
-		}
-
-		if isExtendedPointer {
-			if err := p.Store.Delete(ctx, extendedPointer.Ref()); err != nil {
-				p.emitFailure(ctx, Failure{Kind: FailureDelete, Message: message, Envelope: nil, Err: err})
-				if p.FailOnDeleteError {
-					failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
-				}
-			}
+		if err := p.deletePointer(ctx, pointer, message); err != nil && p.FailOnDeleteError {
+			failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: messageID})
 		}
 	}
 
 	return events.SQSEventResponse{BatchItemFailures: failures}, nil
+}
+
+func (p BatchProcessor) hydratePointer(ctx context.Context, pointer offloadPointer) ([]byte, error) {
+	if p.Store == nil {
+		return nil, errors.New("sqs large payload store is nil")
+	}
+
+	switch pointer.kind {
+	case offloadPointerLiftEnvelope:
+		if pointer.envelope == nil {
+			return nil, errors.New("sqs large payload envelope is nil")
+		}
+		return Hydrate(ctx, p.Store, *pointer.envelope, p.Options)
+	case offloadPointerSQSExtendedClient:
+		return p.Store.Get(ctx, pointer.extended.Ref())
+	default:
+		return nil, errors.New("sqs large payload pointer is not offloaded")
+	}
+}
+
+func (p BatchProcessor) deletePointer(ctx context.Context, pointer offloadPointer, message Message) error {
+	if p.Store == nil {
+		return nil
+	}
+
+	switch pointer.kind {
+	case offloadPointerLiftEnvelope:
+		if pointer.envelope == nil {
+			return nil
+		}
+		if err := Delete(ctx, p.Store, *pointer.envelope); err != nil {
+			p.emitFailure(ctx, Failure{Kind: FailureDelete, Message: message, Envelope: pointer.envelope, Err: err})
+			return err
+		}
+	case offloadPointerSQSExtendedClient:
+		if err := p.Store.Delete(ctx, pointer.extended.Ref()); err != nil {
+			p.emitFailure(ctx, Failure{Kind: FailureDelete, Message: message, Envelope: nil, Err: err})
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (p BatchProcessor) emitFailure(ctx context.Context, failure Failure) {
@@ -213,4 +227,32 @@ func parseLiftEnvelope(body []byte) (*Envelope, bool, error) {
 		return nil, true, err
 	}
 	return &envelope, true, nil
+}
+
+type offloadPointerKind uint8
+
+const (
+	offloadPointerNone offloadPointerKind = iota
+	offloadPointerLiftEnvelope
+	offloadPointerSQSExtendedClient
+)
+
+type offloadPointer struct {
+	envelope *Envelope
+	extended SQSExtendedClientPointer
+	kind     offloadPointerKind
+}
+
+func parseOffloadPointer(body []byte) (offloadPointer, error) {
+	envelope, isEnvelope, err := parseLiftEnvelope(body)
+	if isEnvelope {
+		return offloadPointer{kind: offloadPointerLiftEnvelope, envelope: envelope}, err
+	}
+
+	pointer, ok, err := ParseSQSExtendedClientPointer(body)
+	if ok {
+		return offloadPointer{kind: offloadPointerSQSExtendedClient, extended: pointer}, err
+	}
+
+	return offloadPointer{kind: offloadPointerNone}, nil
 }

--- a/pkg/services/sqs_large_payload/batch.go
+++ b/pkg/services/sqs_large_payload/batch.go
@@ -91,17 +91,26 @@ func (p BatchProcessor) Process(ctx context.Context, records []events.SQSMessage
 
 		rawBody := []byte(record.Body)
 
-		envelope, isEnvelope, err := parseLiftEnvelope(rawBody)
 		message := Message{
 			Record:  record,
 			RawBody: rawBody,
 		}
 
-		if isEnvelope {
-			message.Envelope = envelope
-			if err != nil {
+		envelope, isEnvelope, err := parseLiftEnvelope(rawBody)
+		extendedPointer, isExtendedPointer, extErr := ParseSQSExtendedClientPointer(rawBody)
+
+		if isEnvelope || isExtendedPointer {
+			if isEnvelope {
+				message.Envelope = envelope
+			}
+
+			if err != nil || extErr != nil {
 				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
-				p.emitFailure(ctx, Failure{Kind: FailureHydrate, Message: message, Envelope: envelope, Err: err})
+				if err != nil {
+					p.emitFailure(ctx, Failure{Kind: FailureHydrate, Message: message, Envelope: envelope, Err: err})
+				} else {
+					p.emitFailure(ctx, Failure{Kind: FailureHydrate, Message: message, Envelope: nil, Err: extErr})
+				}
 				continue
 			}
 
@@ -116,7 +125,13 @@ func (p BatchProcessor) Process(ctx context.Context, records []events.SQSMessage
 				continue
 			}
 
-			payload, err := Hydrate(ctx, p.Store, *envelope, p.Options)
+			var payload []byte
+			if isEnvelope {
+				payload, err = Hydrate(ctx, p.Store, *envelope, p.Options)
+			} else {
+				payload, err = p.Store.Get(ctx, extendedPointer.Ref())
+			}
+
 			if err != nil {
 				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
 				p.emitFailure(ctx, Failure{Kind: FailureHydrate, Message: message, Envelope: envelope, Err: err})
@@ -133,14 +148,26 @@ func (p BatchProcessor) Process(ctx context.Context, records []events.SQSMessage
 			continue
 		}
 
-		if envelope == nil || p.Store == nil {
+		if p.Store == nil {
 			continue
 		}
 
-		if err := Delete(ctx, p.Store, *envelope); err != nil {
-			p.emitFailure(ctx, Failure{Kind: FailureDelete, Message: message, Envelope: envelope, Err: err})
-			if p.FailOnDeleteError {
-				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
+		if isEnvelope && envelope != nil {
+			if err := Delete(ctx, p.Store, *envelope); err != nil {
+				p.emitFailure(ctx, Failure{Kind: FailureDelete, Message: message, Envelope: envelope, Err: err})
+				if p.FailOnDeleteError {
+					failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
+				}
+			}
+			continue
+		}
+
+		if isExtendedPointer {
+			if err := p.Store.Delete(ctx, extendedPointer.Ref()); err != nil {
+				p.emitFailure(ctx, Failure{Kind: FailureDelete, Message: message, Envelope: nil, Err: err})
+				if p.FailOnDeleteError {
+					failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
+				}
 			}
 		}
 	}

--- a/pkg/services/sqs_large_payload/batch.go
+++ b/pkg/services/sqs_large_payload/batch.go
@@ -1,0 +1,189 @@
+package sqslargepayload
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// FailureKind categorizes failures encountered while processing SQS messages.
+type FailureKind string
+
+const (
+	FailureHydrate FailureKind = "hydrate"
+	FailureHandler FailureKind = "handler"
+	FailureDelete  FailureKind = "delete"
+)
+
+// Failure describes an error encountered while processing an individual SQS message.
+type Failure struct {
+	Kind     FailureKind
+	Message  Message
+	Envelope *Envelope
+	Err      error
+}
+
+func (f Failure) Error() string {
+	messageID := f.Message.Record.MessageId
+	if messageID == "" {
+		messageID = "<missing>"
+	}
+	return fmt.Sprintf("sqs large payload %s failure for message %s: %v", f.Kind, messageID, f.Err)
+}
+
+func (f Failure) Unwrap() error {
+	return f.Err
+}
+
+// BatchHooks provides callback hooks for observing failures during batch processing.
+type BatchHooks struct {
+	OnFailure        func(ctx context.Context, failure Failure)
+	OnHydrateFailure func(ctx context.Context, failure Failure)
+	OnHandlerFailure func(ctx context.Context, failure Failure)
+	OnDeleteFailure  func(ctx context.Context, failure Failure)
+}
+
+// Message is the per-record context passed to the user handler.
+type Message struct {
+	Record   events.SQSMessage
+	RawBody  []byte
+	Payload  []byte
+	Envelope *Envelope
+}
+
+// MessageHandler processes an individual message (inline or hydrated).
+// Returning an error marks the message as failed in the batch response.
+type MessageHandler func(ctx context.Context, message Message) error
+
+// BatchProcessor processes SQS event batches containing a mix of inline and S3-offloaded payloads.
+//
+// For each record:
+//   - If the body is a Lift large-payload envelope, hydrate from the object store.
+//   - Call the per-message handler with the hydrated payload bytes.
+//   - On handler success, delete the S3 object (best-effort by default).
+//   - Return an events.SQSEventResponse containing only the failed message IDs.
+type BatchProcessor struct {
+	Store             ObjectStore
+	Options           Options
+	FailOnDeleteError bool
+	Hooks             BatchHooks
+}
+
+// Process handles a batch of SQS messages and returns an SQS batch response suitable for
+// ReportBatchItemFailures.
+func (p BatchProcessor) Process(ctx context.Context, records []events.SQSMessage, handler MessageHandler) (events.SQSEventResponse, error) {
+	if handler == nil {
+		return events.SQSEventResponse{}, errors.New("sqs large payload batch handler is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	failures := make([]events.SQSBatchItemFailure, 0)
+
+	for _, record := range records {
+		if record.MessageId == "" {
+			return events.SQSEventResponse{}, errors.New("sqs message missing messageId")
+		}
+
+		rawBody := []byte(record.Body)
+
+		envelope, isEnvelope, err := parseLiftEnvelope(rawBody)
+		message := Message{
+			Record:  record,
+			RawBody: rawBody,
+		}
+
+		if isEnvelope {
+			message.Envelope = envelope
+			if err != nil {
+				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
+				p.emitFailure(ctx, Failure{Kind: FailureHydrate, Message: message, Envelope: envelope, Err: err})
+				continue
+			}
+
+			if p.Store == nil {
+				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
+				p.emitFailure(ctx, Failure{
+					Kind:     FailureHydrate,
+					Message:  message,
+					Envelope: envelope,
+					Err:      errors.New("sqs large payload store is nil"),
+				})
+				continue
+			}
+
+			payload, err := Hydrate(ctx, p.Store, *envelope, p.Options)
+			if err != nil {
+				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
+				p.emitFailure(ctx, Failure{Kind: FailureHydrate, Message: message, Envelope: envelope, Err: err})
+				continue
+			}
+			message.Payload = payload
+		} else {
+			message.Payload = rawBody
+		}
+
+		if err := handler(ctx, message); err != nil {
+			failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
+			p.emitFailure(ctx, Failure{Kind: FailureHandler, Message: message, Envelope: envelope, Err: err})
+			continue
+		}
+
+		if envelope == nil || p.Store == nil {
+			continue
+		}
+
+		if err := Delete(ctx, p.Store, *envelope); err != nil {
+			p.emitFailure(ctx, Failure{Kind: FailureDelete, Message: message, Envelope: envelope, Err: err})
+			if p.FailOnDeleteError {
+				failures = append(failures, events.SQSBatchItemFailure{ItemIdentifier: record.MessageId})
+			}
+		}
+	}
+
+	return events.SQSEventResponse{BatchItemFailures: failures}, nil
+}
+
+func (p BatchProcessor) emitFailure(ctx context.Context, failure Failure) {
+	switch failure.Kind {
+	case FailureHydrate:
+		if p.Hooks.OnHydrateFailure != nil {
+			p.Hooks.OnHydrateFailure(ctx, failure)
+		}
+	case FailureHandler:
+		if p.Hooks.OnHandlerFailure != nil {
+			p.Hooks.OnHandlerFailure(ctx, failure)
+		}
+	case FailureDelete:
+		if p.Hooks.OnDeleteFailure != nil {
+			p.Hooks.OnDeleteFailure(ctx, failure)
+		}
+	}
+
+	if p.Hooks.OnFailure != nil {
+		p.Hooks.OnFailure(ctx, failure)
+	}
+}
+
+func parseLiftEnvelope(body []byte) (*Envelope, bool, error) {
+	var probe struct {
+		Type string `json:"type"`
+	}
+
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return nil, false, nil
+	}
+	if probe.Type != EnvelopeTypeV1 {
+		return nil, false, nil
+	}
+
+	envelope, err := ParseEnvelope(body)
+	if err != nil {
+		return nil, true, err
+	}
+	return &envelope, true, nil
+}

--- a/pkg/services/sqs_large_payload/batch_test.go
+++ b/pkg/services/sqs_large_payload/batch_test.go
@@ -1,0 +1,258 @@
+package sqslargepayload
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func TestBatchProcessor_MixedBatchDeletesOnlySuccessfulLargePayloadObjects(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+
+	okRef := Ref{Bucket: "bucket", Key: "sqs/queue/messages/ok"}
+	okPayload := []byte("ok-payload")
+	requireStorePut(t, store, okRef, okPayload)
+
+	okEnv := Envelope{
+		Type:   EnvelopeTypeV1,
+		Bucket: okRef.Bucket,
+		Key:    okRef.Key,
+		SHA256: sha256Hex(okPayload),
+		Bytes:  int64(len(okPayload)),
+	}
+	okBody := mustMarshalEnvelope(t, okEnv)
+
+	failRef := Ref{Bucket: "bucket", Key: "sqs/queue/messages/fail"}
+	failPayload := []byte("fail-payload")
+	requireStorePut(t, store, failRef, failPayload)
+
+	failEnv := Envelope{
+		Type:   EnvelopeTypeV1,
+		Bucket: failRef.Bucket,
+		Key:    failRef.Key,
+		SHA256: sha256Hex(failPayload),
+		Bytes:  int64(len(failPayload)),
+	}
+	failBody := mustMarshalEnvelope(t, failEnv)
+
+	records := []events.SQSMessage{
+		{MessageId: "inline-1", Body: "inline"},
+		{MessageId: "offload-ok", Body: string(okBody)},
+		{MessageId: "offload-fail", Body: string(failBody)},
+	}
+
+	processor := BatchProcessor{Store: store}
+
+	resp, err := processor.Process(ctx, records, func(_ context.Context, msg Message) error {
+		switch msg.Record.MessageId {
+		case "inline-1":
+			if string(msg.Payload) != "inline" {
+				t.Fatalf("expected inline payload, got %q", msg.Payload)
+			}
+			if msg.Envelope != nil {
+				t.Fatalf("expected no envelope for inline message")
+			}
+			return nil
+		case "offload-ok":
+			if string(msg.Payload) != string(okPayload) {
+				t.Fatalf("expected hydrated ok payload, got %q", msg.Payload)
+			}
+			if msg.Envelope == nil {
+				t.Fatalf("expected envelope for offloaded message")
+			}
+			return nil
+		case "offload-fail":
+			if string(msg.Payload) != string(failPayload) {
+				t.Fatalf("expected hydrated fail payload, got %q", msg.Payload)
+			}
+			return errors.New("boom")
+		default:
+			return nil
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.BatchItemFailures) != 1 || resp.BatchItemFailures[0].ItemIdentifier != "offload-fail" {
+		t.Fatalf("expected one failed message offload-fail, got %#v", resp.BatchItemFailures)
+	}
+
+	if store.deletes != 1 {
+		t.Fatalf("expected exactly 1 delete (successful offloaded message), got %d", store.deletes)
+	}
+
+	if _, err := store.Get(ctx, okRef); err == nil {
+		t.Fatalf("expected ok payload object to be deleted")
+	}
+	if got, err := store.Get(ctx, failRef); err != nil || string(got) != string(failPayload) {
+		t.Fatalf("expected failed payload object to remain; got=%q err=%v", got, err)
+	}
+}
+
+func TestBatchProcessor_DeleteFailureDoesNotFailMessageByDefault(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+
+	ref := Ref{Bucket: "bucket", Key: "sqs/queue/messages/delete-fail"}
+	payload := []byte("payload")
+	requireStorePut(t, store, ref, payload)
+
+	env := Envelope{
+		Type:   EnvelopeTypeV1,
+		Bucket: ref.Bucket,
+		Key:    ref.Key,
+		SHA256: sha256Hex(payload),
+		Bytes:  int64(len(payload)),
+	}
+	body := mustMarshalEnvelope(t, env)
+
+	deleteErr := errors.New("delete failed")
+	failStore := deleteFailStore{
+		memoryStore: store,
+		failRef:     ref,
+		deleteErr:   deleteErr,
+	}
+
+	seenDeleteFailure := 0
+	processor := BatchProcessor{
+		Store: failStore,
+		Hooks: BatchHooks{
+			OnDeleteFailure: func(_ context.Context, failure Failure) {
+				if !errors.Is(failure.Err, deleteErr) {
+					t.Fatalf("expected delete error to propagate")
+				}
+				seenDeleteFailure++
+			},
+		},
+	}
+
+	resp, err := processor.Process(ctx, []events.SQSMessage{
+		{MessageId: "msg-1", Body: string(body)},
+	}, func(_ context.Context, _ Message) error { return nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.BatchItemFailures) != 0 {
+		t.Fatalf("expected no failures, got %#v", resp.BatchItemFailures)
+	}
+	if seenDeleteFailure != 1 {
+		t.Fatalf("expected delete failure hook to be called once, got %d", seenDeleteFailure)
+	}
+}
+
+func TestBatchProcessor_DeleteFailureFailsMessageWhenStrict(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+
+	ref := Ref{Bucket: "bucket", Key: "sqs/queue/messages/delete-fail"}
+	payload := []byte("payload")
+	requireStorePut(t, store, ref, payload)
+
+	env := Envelope{
+		Type:   EnvelopeTypeV1,
+		Bucket: ref.Bucket,
+		Key:    ref.Key,
+		SHA256: sha256Hex(payload),
+		Bytes:  int64(len(payload)),
+	}
+	body := mustMarshalEnvelope(t, env)
+
+	failStore := deleteFailStore{
+		memoryStore: store,
+		failRef:     ref,
+		deleteErr:   errors.New("delete failed"),
+	}
+
+	processor := BatchProcessor{
+		Store:             failStore,
+		FailOnDeleteError: true,
+	}
+
+	resp, err := processor.Process(ctx, []events.SQSMessage{
+		{MessageId: "msg-1", Body: string(body)},
+	}, func(_ context.Context, _ Message) error { return nil })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.BatchItemFailures) != 1 || resp.BatchItemFailures[0].ItemIdentifier != "msg-1" {
+		t.Fatalf("expected msg-1 to fail due to delete error, got %#v", resp.BatchItemFailures)
+	}
+}
+
+func TestBatchProcessor_HydrateFailureMarksMessageFailed(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+
+	missingRef := Ref{Bucket: "bucket", Key: "sqs/queue/messages/missing"}
+	payload := []byte("payload")
+	env := Envelope{
+		Type:   EnvelopeTypeV1,
+		Bucket: missingRef.Bucket,
+		Key:    missingRef.Key,
+		SHA256: sha256Hex(payload),
+		Bytes:  int64(len(payload)),
+	}
+	body := mustMarshalEnvelope(t, env)
+
+	seenHandler := 0
+	processor := BatchProcessor{Store: store}
+
+	resp, err := processor.Process(ctx, []events.SQSMessage{
+		{MessageId: "msg-1", Body: string(body)},
+	}, func(_ context.Context, _ Message) error {
+		seenHandler++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if seenHandler != 0 {
+		t.Fatalf("expected handler to not be called on hydrate failure")
+	}
+	if len(resp.BatchItemFailures) != 1 || resp.BatchItemFailures[0].ItemIdentifier != "msg-1" {
+		t.Fatalf("expected hydrate failure to mark msg-1 failed, got %#v", resp.BatchItemFailures)
+	}
+}
+
+type deleteFailStore struct {
+	*memoryStore
+	failRef   Ref
+	deleteErr error
+}
+
+func (d deleteFailStore) Delete(_ context.Context, ref Ref) error {
+	if ref == d.failRef {
+		return d.deleteErr
+	}
+	return d.memoryStore.Delete(context.Background(), ref)
+}
+
+func sha256Hex(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func mustMarshalEnvelope(t *testing.T, env Envelope) []byte {
+	t.Helper()
+	encoded, err := MarshalEnvelope(env)
+	if err != nil {
+		t.Fatalf("failed to marshal envelope: %v", err)
+	}
+	return encoded
+}
+
+func requireStorePut(t *testing.T, store ObjectStore, ref Ref, payload []byte) {
+	t.Helper()
+	if err := store.Put(context.Background(), ref, payload); err != nil {
+		t.Fatalf("failed to seed store: %v", err)
+	}
+}

--- a/pkg/services/sqs_large_payload/doc.go
+++ b/pkg/services/sqs_large_payload/doc.go
@@ -6,4 +6,9 @@
 //   - Offload when payload size is > 256KB (no compression).
 //   - SQS message body becomes a JSON envelope containing S3 bucket + key.
 //   - Consumers hydrate from S3 and delete the object on success (TTL is a fallback).
+//
+// Compatibility:
+//   - The BatchProcessor also recognizes S3 pointer bodies produced by the Amazon SQS extended
+//     client libraries (Java/Python), which encode pointers as a JSON array:
+//     [<pointer-class>, {"s3BucketName": "...", "s3Key": "..."}].
 package sqslargepayload

--- a/pkg/services/sqs_large_payload/doc.go
+++ b/pkg/services/sqs_large_payload/doc.go
@@ -1,0 +1,9 @@
+// Package sqslargepayload provides helpers for handling SQS payloads that exceed
+// the 256KB SQS message size limit by storing the full payload in S3 and sending
+// a small pointer envelope through SQS.
+//
+// Design summary:
+//   - Offload when payload size is > 256KB (no compression).
+//   - SQS message body becomes a JSON envelope containing S3 bucket + key.
+//   - Consumers hydrate from S3 and delete the object on success (TTL is a fallback).
+package sqslargepayload

--- a/pkg/services/sqs_large_payload/envelope.go
+++ b/pkg/services/sqs_large_payload/envelope.go
@@ -1,0 +1,175 @@
+package sqslargepayload
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const (
+	// EnvelopeTypeV1 is the pointer envelope version identifier written to SQS message bodies.
+	EnvelopeTypeV1 = "lift:sqs-large-payload:v1"
+
+	// SQSMaxMessageBytes is the hard SQS message size limit (body + attributes).
+	// Lift's large payload support offloads when the serialized body exceeds this limit.
+	SQSMaxMessageBytes = 256 * 1024
+)
+
+var (
+	ErrEnvelopeMissingType   = errors.New("sqs large payload envelope missing type")
+	ErrEnvelopeUnknownType   = errors.New("sqs large payload envelope has unknown type")
+	ErrEnvelopeMissingBucket = errors.New("sqs large payload envelope missing bucket")
+	ErrEnvelopeMissingKey    = errors.New("sqs large payload envelope missing key")
+	ErrIntegrityMismatch     = errors.New("sqs large payload sha256 mismatch")
+)
+
+// Ref identifies an S3 object holding an offloaded payload.
+type Ref struct {
+	Bucket string
+	Key    string
+}
+
+// Envelope is the JSON-encoded SQS message body used when payloads are offloaded to S3.
+type Envelope struct {
+	Type   string `json:"type"`
+	Bucket string `json:"bucket"`
+	Key    string `json:"key"`
+	SHA256 string `json:"sha256,omitempty"`
+	Bytes  int64  `json:"bytes,omitempty"`
+}
+
+// Ref returns the S3 object reference described by the envelope.
+func (e Envelope) Ref() Ref {
+	return Ref{Bucket: e.Bucket, Key: e.Key}
+}
+
+// Validate ensures the envelope is well-formed and uses a supported version.
+func (e Envelope) Validate() error {
+	if e.Type == "" {
+		return ErrEnvelopeMissingType
+	}
+	if e.Type != EnvelopeTypeV1 {
+		return fmt.Errorf("%w: %s", ErrEnvelopeUnknownType, e.Type)
+	}
+	if e.Bucket == "" {
+		return ErrEnvelopeMissingBucket
+	}
+	if e.Key == "" {
+		return ErrEnvelopeMissingKey
+	}
+	return nil
+}
+
+// Options configures offload/hydration behavior.
+type Options struct {
+	// VerifySHA256 enables integrity checks when the envelope includes a sha256 value.
+	// Default: true.
+	VerifySHA256 bool
+}
+
+// DefaultOptions returns the recommended default options.
+func DefaultOptions() Options {
+	return Options{VerifySHA256: true}
+}
+
+// ShouldOffload reports whether the payload should be stored in S3 instead of sent inline via SQS.
+func ShouldOffload(payload []byte) bool {
+	return len(payload) > SQSMaxMessageBytes
+}
+
+// MarshalEnvelope encodes the envelope as JSON.
+func MarshalEnvelope(envelope Envelope) ([]byte, error) {
+	if err := envelope.Validate(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(envelope)
+}
+
+// ParseEnvelope decodes and validates an envelope from JSON.
+func ParseEnvelope(data []byte) (Envelope, error) {
+	var envelope Envelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return Envelope{}, err
+	}
+	if err := envelope.Validate(); err != nil {
+		return Envelope{}, err
+	}
+	return envelope, nil
+}
+
+// ObjectStore defines the minimum storage operations required for offloading and hydrating payloads.
+// Implementations should provide S3-backed storage with least-privilege access.
+type ObjectStore interface {
+	Put(ctx context.Context, ref Ref, payload []byte) error
+	Get(ctx context.Context, ref Ref) ([]byte, error)
+	Delete(ctx context.Context, ref Ref) error
+}
+
+// OffloadIfNeeded stores payload in the provided object store when it exceeds SQS limits and
+// returns the message body bytes that should be sent to SQS.
+//
+// When payload is stored in S3, this returns the marshaled Envelope as the new message body and
+// a non-nil Envelope pointer. When the payload is small enough, this returns the original payload
+// and a nil Envelope pointer.
+func OffloadIfNeeded(ctx context.Context, store ObjectStore, ref Ref, payload []byte, opts Options) ([]byte, *Envelope, error) {
+	if !ShouldOffload(payload) {
+		return payload, nil, nil
+	}
+
+	envelope := Envelope{
+		Type:   EnvelopeTypeV1,
+		Bucket: ref.Bucket,
+		Key:    ref.Key,
+		Bytes:  int64(len(payload)),
+	}
+
+	if opts.VerifySHA256 {
+		sum := sha256.Sum256(payload)
+		envelope.SHA256 = hex.EncodeToString(sum[:])
+	}
+
+	if err := envelope.Validate(); err != nil {
+		return nil, nil, err
+	}
+	if err := store.Put(ctx, ref, payload); err != nil {
+		return nil, nil, err
+	}
+
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, nil, err
+	}
+	return encoded, &envelope, nil
+}
+
+// Hydrate resolves an envelope to its payload bytes, optionally verifying integrity.
+func Hydrate(ctx context.Context, store ObjectStore, envelope Envelope, opts Options) ([]byte, error) {
+	if err := envelope.Validate(); err != nil {
+		return nil, err
+	}
+
+	payload, err := store.Get(ctx, envelope.Ref())
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.VerifySHA256 && envelope.SHA256 != "" {
+		sum := sha256.Sum256(payload)
+		if hex.EncodeToString(sum[:]) != envelope.SHA256 {
+			return nil, ErrIntegrityMismatch
+		}
+	}
+
+	return payload, nil
+}
+
+// Delete deletes the S3 object referenced by the envelope.
+func Delete(ctx context.Context, store ObjectStore, envelope Envelope) error {
+	if err := envelope.Validate(); err != nil {
+		return err
+	}
+	return store.Delete(ctx, envelope.Ref())
+}

--- a/pkg/services/sqs_large_payload/envelope.go
+++ b/pkg/services/sqs_large_payload/envelope.go
@@ -67,12 +67,12 @@ func (e Envelope) Validate() error {
 type Options struct {
 	// VerifySHA256 enables integrity checks when the envelope includes a sha256 value.
 	// Default: true.
-	VerifySHA256 bool
+	VerifySHA256 *bool
 }
 
 // DefaultOptions returns the recommended default options.
 func DefaultOptions() Options {
-	return Options{VerifySHA256: true}
+	return Options{VerifySHA256: boolPtr(true)}
 }
 
 // ShouldOffload reports whether the payload should be stored in S3 instead of sent inline via SQS.
@@ -119,6 +119,11 @@ func OffloadIfNeeded(ctx context.Context, store ObjectStore, ref Ref, payload []
 		return payload, nil, nil
 	}
 
+	verify := true
+	if opts.VerifySHA256 != nil {
+		verify = *opts.VerifySHA256
+	}
+
 	envelope := Envelope{
 		Type:   EnvelopeTypeV1,
 		Bucket: ref.Bucket,
@@ -126,7 +131,7 @@ func OffloadIfNeeded(ctx context.Context, store ObjectStore, ref Ref, payload []
 		Bytes:  int64(len(payload)),
 	}
 
-	if opts.VerifySHA256 {
+	if verify {
 		sum := sha256.Sum256(payload)
 		envelope.SHA256 = hex.EncodeToString(sum[:])
 	}
@@ -151,12 +156,17 @@ func Hydrate(ctx context.Context, store ObjectStore, envelope Envelope, opts Opt
 		return nil, err
 	}
 
+	verify := true
+	if opts.VerifySHA256 != nil {
+		verify = *opts.VerifySHA256
+	}
+
 	payload, err := store.Get(ctx, envelope.Ref())
 	if err != nil {
 		return nil, err
 	}
 
-	if opts.VerifySHA256 && envelope.SHA256 != "" {
+	if verify && envelope.SHA256 != "" {
 		sum := sha256.Sum256(payload)
 		if hex.EncodeToString(sum[:]) != envelope.SHA256 {
 			return nil, ErrIntegrityMismatch
@@ -172,4 +182,8 @@ func Delete(ctx context.Context, store ObjectStore, envelope Envelope) error {
 		return err
 	}
 	return store.Delete(ctx, envelope.Ref())
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }

--- a/pkg/services/sqs_large_payload/envelope_test.go
+++ b/pkg/services/sqs_large_payload/envelope_test.go
@@ -1,0 +1,240 @@
+package sqslargepayload
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"testing"
+)
+
+func TestShouldOffload(t *testing.T) {
+	payload := make([]byte, SQSMaxMessageBytes)
+	if ShouldOffload(payload) {
+		t.Fatalf("expected payload at limit (%d) to not offload", SQSMaxMessageBytes)
+	}
+
+	payload = make([]byte, SQSMaxMessageBytes+1)
+	if !ShouldOffload(payload) {
+		t.Fatalf("expected payload over limit (%d) to offload", SQSMaxMessageBytes)
+	}
+}
+
+func TestParseEnvelope_Validation(t *testing.T) {
+	_, err := ParseEnvelope([]byte(`{"bucket":"b","key":"k"}`))
+	if !errors.Is(err, ErrEnvelopeMissingType) {
+		t.Fatalf("expected ErrEnvelopeMissingType, got %v", err)
+	}
+
+	_, err = ParseEnvelope([]byte(`{"type":"unknown","bucket":"b","key":"k"}`))
+	if !errors.Is(err, ErrEnvelopeUnknownType) {
+		t.Fatalf("expected ErrEnvelopeUnknownType, got %v", err)
+	}
+
+	_, err = ParseEnvelope([]byte(`{"type":"` + EnvelopeTypeV1 + `","key":"k"}`))
+	if !errors.Is(err, ErrEnvelopeMissingBucket) {
+		t.Fatalf("expected ErrEnvelopeMissingBucket, got %v", err)
+	}
+
+	_, err = ParseEnvelope([]byte(`{"type":"` + EnvelopeTypeV1 + `","bucket":"b"}`))
+	if !errors.Is(err, ErrEnvelopeMissingKey) {
+		t.Fatalf("expected ErrEnvelopeMissingKey, got %v", err)
+	}
+}
+
+func TestOffloadIfNeeded_NoOffload(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+	ref := Ref{Bucket: "bucket", Key: "key"}
+	payload := []byte("small")
+
+	body, envelope, err := OffloadIfNeeded(ctx, store, ref, payload, Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envelope != nil {
+		t.Fatalf("expected nil envelope when not offloading, got %#v", envelope)
+	}
+	if string(body) != string(payload) {
+		t.Fatalf("expected original payload to be returned")
+	}
+	if store.puts != 0 {
+		t.Fatalf("expected no store puts, got %d", store.puts)
+	}
+}
+
+func TestOffloadIfNeeded_OffloadsAndReturnsEnvelope(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+	ref := Ref{Bucket: "bucket", Key: "sqs/queue/messages/abc"}
+	payload := make([]byte, SQSMaxMessageBytes+1)
+	payload[0] = 0x7f
+
+	body, envelope, err := OffloadIfNeeded(ctx, store, ref, payload, Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if envelope == nil {
+		t.Fatalf("expected envelope when offloading")
+	}
+	if store.puts != 1 {
+		t.Fatalf("expected exactly 1 store put, got %d", store.puts)
+	}
+
+	got, err := ParseEnvelope(body)
+	if err != nil {
+		t.Fatalf("expected returned body to be an envelope, got error: %v", err)
+	}
+	if got.Bucket != ref.Bucket || got.Key != ref.Key {
+		t.Fatalf("expected envelope ref to match, got bucket=%q key=%q", got.Bucket, got.Key)
+	}
+	if got.Bytes != int64(len(payload)) {
+		t.Fatalf("expected envelope bytes=%d got %d", len(payload), got.Bytes)
+	}
+	if got.SHA256 == "" {
+		t.Fatalf("expected sha256 to be set by default")
+	}
+
+	stored, err := store.Get(ctx, ref)
+	if err != nil {
+		t.Fatalf("unexpected get error: %v", err)
+	}
+	if len(stored) != len(payload) || stored[0] != payload[0] {
+		t.Fatalf("expected stored payload to match original")
+	}
+}
+
+func TestOffloadIfNeeded_DisableSHA256(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+	ref := Ref{Bucket: "bucket", Key: "sqs/queue/messages/abc"}
+	payload := make([]byte, SQSMaxMessageBytes+1)
+
+	verify := false
+	body, _, err := OffloadIfNeeded(ctx, store, ref, payload, Options{VerifySHA256: &verify})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := ParseEnvelope(body)
+	if err != nil {
+		t.Fatalf("expected returned body to be an envelope, got error: %v", err)
+	}
+	if got.SHA256 != "" {
+		t.Fatalf("expected sha256 to be omitted when disabled, got %q", got.SHA256)
+	}
+}
+
+func TestHydrate_VerifyIntegrity_DefaultOn(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+	ref := Ref{Bucket: "bucket", Key: "key"}
+	payload := []byte("payload")
+	if err := store.Put(ctx, ref, payload); err != nil {
+		t.Fatalf("unexpected put error: %v", err)
+	}
+
+	sum := sha256.Sum256(payload)
+	envelope := Envelope{
+		Type:   EnvelopeTypeV1,
+		Bucket: ref.Bucket,
+		Key:    ref.Key,
+		SHA256: hex.EncodeToString(sum[:]),
+		Bytes:  int64(len(payload)),
+	}
+
+	out, err := Hydrate(ctx, store, envelope, Options{})
+	if err != nil {
+		t.Fatalf("unexpected hydrate error: %v", err)
+	}
+	if string(out) != string(payload) {
+		t.Fatalf("expected hydrated payload to match")
+	}
+}
+
+func TestHydrate_IntegrityMismatch(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+	ref := Ref{Bucket: "bucket", Key: "key"}
+
+	right := []byte("right")
+	wrong := []byte("wrong")
+	if err := store.Put(ctx, ref, wrong); err != nil {
+		t.Fatalf("unexpected put error: %v", err)
+	}
+
+	sum := sha256.Sum256(right)
+	envelope := Envelope{
+		Type:   EnvelopeTypeV1,
+		Bucket: ref.Bucket,
+		Key:    ref.Key,
+		SHA256: hex.EncodeToString(sum[:]),
+		Bytes:  int64(len(right)),
+	}
+
+	_, err := Hydrate(ctx, store, envelope, Options{})
+	if !errors.Is(err, ErrIntegrityMismatch) {
+		t.Fatalf("expected ErrIntegrityMismatch, got %v", err)
+	}
+}
+
+func TestDelete_RemovesObject(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+	ref := Ref{Bucket: "bucket", Key: "key"}
+	if err := store.Put(ctx, ref, []byte("payload")); err != nil {
+		t.Fatalf("unexpected put error: %v", err)
+	}
+
+	envelope := Envelope{
+		Type:   EnvelopeTypeV1,
+		Bucket: ref.Bucket,
+		Key:    ref.Key,
+	}
+
+	if err := Delete(ctx, store, envelope); err != nil {
+		t.Fatalf("unexpected delete error: %v", err)
+	}
+	if store.deletes != 1 {
+		t.Fatalf("expected exactly 1 delete, got %d", store.deletes)
+	}
+	if _, err := store.Get(ctx, ref); err == nil {
+		t.Fatalf("expected object to be deleted")
+	}
+}
+
+type memoryStore struct {
+	objects map[Ref][]byte
+	puts    int
+	gets    int
+	deletes int
+}
+
+func newMemoryStore() *memoryStore {
+	return &memoryStore{objects: make(map[Ref][]byte)}
+}
+
+func (m *memoryStore) Put(_ context.Context, ref Ref, payload []byte) error {
+	m.puts++
+	copied := make([]byte, len(payload))
+	copy(copied, payload)
+	m.objects[ref] = copied
+	return nil
+}
+
+func (m *memoryStore) Get(_ context.Context, ref Ref) ([]byte, error) {
+	m.gets++
+	payload, ok := m.objects[ref]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	copied := make([]byte, len(payload))
+	copy(copied, payload)
+	return copied, nil
+}
+
+func (m *memoryStore) Delete(_ context.Context, ref Ref) error {
+	m.deletes++
+	delete(m.objects, ref)
+	return nil
+}

--- a/pkg/services/sqs_large_payload/extended_client.go
+++ b/pkg/services/sqs_large_payload/extended_client.go
@@ -1,0 +1,111 @@
+package sqslargepayload
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const (
+	// SQSExtendedClientReservedAttributeName is the reserved message attribute name used by the
+	// Amazon SQS extended client libraries for payload size metadata.
+	SQSExtendedClientReservedAttributeName = "ExtendedPayloadSize"
+
+	// SQSExtendedClientLegacyReservedAttributeName is the legacy reserved attribute name used by
+	// older extended client implementations.
+	SQSExtendedClientLegacyReservedAttributeName = "SQSLargePayloadSize"
+
+	// SQSExtendedClientPointerClass is the pointer class name written into the message body by
+	// newer SQS extended client implementations.
+	SQSExtendedClientPointerClass = "software.amazon.payloadoffloading.PayloadS3Pointer"
+
+	// SQSExtendedClientLegacyPointerClass is the pointer class name written into the message body by
+	// legacy SQS extended client implementations.
+	SQSExtendedClientLegacyPointerClass = "com.amazon.sqs.javamessaging.MessageS3Pointer"
+)
+
+var (
+	ErrSQSExtendedClientPointerMissingBucket = errors.New("sqs extended client pointer missing s3BucketName")
+	ErrSQSExtendedClientPointerMissingKey    = errors.New("sqs extended client pointer missing s3Key")
+	ErrSQSExtendedClientPointerUnknownClass  = errors.New("sqs extended client pointer has unknown class")
+)
+
+// SQSExtendedClientPointer describes the S3 object pointer format used by the Amazon SQS
+// extended client libraries (Java/Python).
+//
+// The SQS message body is a JSON array containing:
+//   - a pointer class name (string)
+//   - a dictionary containing s3BucketName + s3Key
+type SQSExtendedClientPointer struct {
+	Class  string
+	Bucket string
+	Key    string
+}
+
+// Ref returns the S3 object reference described by the pointer.
+func (p SQSExtendedClientPointer) Ref() Ref {
+	return Ref{Bucket: p.Bucket, Key: p.Key}
+}
+
+// Validate ensures the pointer is well-formed and uses a supported class name.
+func (p SQSExtendedClientPointer) Validate() error {
+	switch p.Class {
+	case SQSExtendedClientPointerClass, SQSExtendedClientLegacyPointerClass:
+	default:
+		if p.Class == "" {
+			return fmt.Errorf("%w: <missing>", ErrSQSExtendedClientPointerUnknownClass)
+		}
+		return fmt.Errorf("%w: %s", ErrSQSExtendedClientPointerUnknownClass, p.Class)
+	}
+
+	if p.Bucket == "" {
+		return ErrSQSExtendedClientPointerMissingBucket
+	}
+	if p.Key == "" {
+		return ErrSQSExtendedClientPointerMissingKey
+	}
+	return nil
+}
+
+// ParseSQSExtendedClientPointer detects and parses the pointer format used by the Amazon SQS
+// extended client libraries.
+//
+// Returns (pointer, true, nil) when data matches the expected format.
+// Returns (zero, false, nil) when data does not appear to be an extended-client pointer.
+func ParseSQSExtendedClientPointer(data []byte) (SQSExtendedClientPointer, bool, error) {
+	var parts []json.RawMessage
+	if err := json.Unmarshal(data, &parts); err != nil {
+		return SQSExtendedClientPointer{}, false, nil
+	}
+	if len(parts) != 2 {
+		return SQSExtendedClientPointer{}, false, nil
+	}
+
+	var class string
+	if err := json.Unmarshal(parts[0], &class); err != nil {
+		return SQSExtendedClientPointer{}, false, nil
+	}
+	if class != SQSExtendedClientPointerClass && class != SQSExtendedClientLegacyPointerClass {
+		return SQSExtendedClientPointer{}, false, nil
+	}
+
+	var details struct {
+		Bucket string `json:"s3BucketName"`
+		Key    string `json:"s3Key"`
+	}
+	if err := json.Unmarshal(parts[1], &details); err != nil {
+		return SQSExtendedClientPointer{}, true, err
+	}
+
+	pointer := SQSExtendedClientPointer{
+		Class:  class,
+		Bucket: details.Bucket,
+		Key:    details.Key,
+	}
+	if err := pointer.Validate(); err != nil {
+		return SQSExtendedClientPointer{}, true, err
+	}
+
+	return pointer, true, nil
+}
+

--- a/pkg/services/sqs_large_payload/extended_client.go
+++ b/pkg/services/sqs_large_payload/extended_client.go
@@ -108,4 +108,3 @@ func ParseSQSExtendedClientPointer(data []byte) (SQSExtendedClientPointer, bool,
 
 	return pointer, true, nil
 }
-

--- a/pkg/services/sqs_large_payload/extended_client_test.go
+++ b/pkg/services/sqs_large_payload/extended_client_test.go
@@ -1,0 +1,158 @@
+package sqslargepayload
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func TestParseSQSExtendedClientPointer_ParsesKnownFormat(t *testing.T) {
+	body := mustMarshalJSON(t, []any{
+		SQSExtendedClientPointerClass,
+		map[string]string{"s3BucketName": "bucket", "s3Key": "key"},
+	})
+
+	pointer, ok, err := ParseSQSExtendedClientPointer(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if pointer.Class != SQSExtendedClientPointerClass {
+		t.Fatalf("expected class %q, got %q", SQSExtendedClientPointerClass, pointer.Class)
+	}
+	if pointer.Bucket != "bucket" || pointer.Key != "key" {
+		t.Fatalf("unexpected pointer fields: %#v", pointer)
+	}
+}
+
+func TestParseSQSExtendedClientPointer_ReturnsFalseForNonPointerBodies(t *testing.T) {
+	cases := [][]byte{
+		[]byte("not json"),
+		mustMarshalJSON(t, map[string]any{"type": "lift:something"}),
+		mustMarshalJSON(t, []any{"not-a-pointer-class", map[string]string{"s3BucketName": "b", "s3Key": "k"}}),
+	}
+
+	for i, body := range cases {
+		_, ok, err := ParseSQSExtendedClientPointer(body)
+		if err != nil {
+			t.Fatalf("case %d: unexpected error: %v", i, err)
+		}
+		if ok {
+			t.Fatalf("case %d: expected ok=false", i)
+		}
+	}
+}
+
+func TestParseSQSExtendedClientPointer_ErrorsOnMalformedPointer(t *testing.T) {
+	body := mustMarshalJSON(t, []any{
+		SQSExtendedClientPointerClass,
+		map[string]string{"s3BucketName": "bucket"},
+	})
+
+	_, ok, err := ParseSQSExtendedClientPointer(body)
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestBatchProcessor_HydratesAndDeletesSQSExtendedClientPointers(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+
+	ref := Ref{Bucket: "bucket", Key: "key"}
+	payload := []byte("payload")
+	requireStorePut(t, store, ref, payload)
+
+	pointerBody := mustMarshalJSON(t, []any{
+		SQSExtendedClientPointerClass,
+		map[string]string{"s3BucketName": ref.Bucket, "s3Key": ref.Key},
+	})
+
+	processor := BatchProcessor{Store: store}
+
+	resp, err := processor.Process(ctx, []events.SQSMessage{
+		{
+			MessageId: "msg-1",
+			Body:      string(pointerBody),
+			MessageAttributes: map[string]events.SQSMessageAttribute{
+				SQSExtendedClientReservedAttributeName: {DataType: "Number", StringValue: strPtr("7")},
+			},
+		},
+	}, func(_ context.Context, msg Message) error {
+		if msg.Envelope != nil {
+			t.Fatalf("expected Envelope to be nil for extended-client pointer messages")
+		}
+		if string(msg.Payload) != string(payload) {
+			t.Fatalf("expected hydrated payload %q, got %q", payload, msg.Payload)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.BatchItemFailures) != 0 {
+		t.Fatalf("expected no failures, got %#v", resp.BatchItemFailures)
+	}
+	if store.deletes != 1 {
+		t.Fatalf("expected exactly 1 delete, got %d", store.deletes)
+	}
+	if _, err := store.Get(ctx, ref); err == nil {
+		t.Fatalf("expected payload object to be deleted")
+	}
+}
+
+func TestBatchProcessor_DoesNotDeleteFailedSQSExtendedClientPointers(t *testing.T) {
+	ctx := context.Background()
+	store := newMemoryStore()
+
+	ref := Ref{Bucket: "bucket", Key: "key"}
+	payload := []byte("payload")
+	requireStorePut(t, store, ref, payload)
+
+	pointerBody := mustMarshalJSON(t, []any{
+		SQSExtendedClientPointerClass,
+		map[string]string{"s3BucketName": ref.Bucket, "s3Key": ref.Key},
+	})
+
+	processor := BatchProcessor{Store: store}
+
+	resp, err := processor.Process(ctx, []events.SQSMessage{
+		{MessageId: "msg-1", Body: string(pointerBody)},
+	}, func(_ context.Context, _ Message) error {
+		return errors.New("boom")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.BatchItemFailures) != 1 || resp.BatchItemFailures[0].ItemIdentifier != "msg-1" {
+		t.Fatalf("expected msg-1 to fail, got %#v", resp.BatchItemFailures)
+	}
+	if store.deletes != 0 {
+		t.Fatalf("expected no deletes on handler failure, got %d", store.deletes)
+	}
+	if got, err := store.Get(ctx, ref); err != nil || string(got) != string(payload) {
+		t.Fatalf("expected payload object to remain; got=%q err=%v", got, err)
+	}
+}
+
+func mustMarshalJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal json: %v", err)
+	}
+	return data
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+

--- a/pkg/services/sqs_large_payload/extended_client_test.go
+++ b/pkg/services/sqs_large_payload/extended_client_test.go
@@ -155,4 +155,3 @@ func mustMarshalJSON(t *testing.T, v any) []byte {
 func strPtr(s string) *string {
 	return &s
 }
-

--- a/pkg/services/sqs_large_payload/s3_store.go
+++ b/pkg/services/sqs_large_payload/s3_store.go
@@ -1,0 +1,93 @@
+package sqslargepayload
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+var (
+	ErrNilS3Client = errors.New("sqs large payload s3 store client is nil")
+	ErrInvalidRef  = errors.New("sqs large payload ref missing bucket or key")
+)
+
+// S3API defines the subset of the AWS SDK S3 client used by Lift's large payload helpers.
+type S3API interface {
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
+
+// S3Store implements ObjectStore using AWS S3 (AWS SDK v2).
+type S3Store struct {
+	Client S3API
+}
+
+// Put stores the payload at the specified bucket + key.
+func (s S3Store) Put(ctx context.Context, ref Ref, payload []byte) error {
+	if s.Client == nil {
+		return ErrNilS3Client
+	}
+	if err := validateRef(ref); err != nil {
+		return err
+	}
+
+	_, err := s.Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: &ref.Bucket,
+		Key:    &ref.Key,
+		Body:   bytes.NewReader(payload),
+	})
+	return err
+}
+
+// Get retrieves the payload bytes from the specified bucket + key.
+func (s S3Store) Get(ctx context.Context, ref Ref) ([]byte, error) {
+	if s.Client == nil {
+		return nil, ErrNilS3Client
+	}
+	if err := validateRef(ref); err != nil {
+		return nil, err
+	}
+
+	out, err := s.Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &ref.Bucket,
+		Key:    &ref.Key,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = out.Body.Close() }()
+
+	payload, err := io.ReadAll(out.Body)
+	if err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+// Delete deletes the payload object from the specified bucket + key.
+func (s S3Store) Delete(ctx context.Context, ref Ref) error {
+	if s.Client == nil {
+		return ErrNilS3Client
+	}
+	if err := validateRef(ref); err != nil {
+		return err
+	}
+
+	_, err := s.Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: &ref.Bucket,
+		Key:    &ref.Key,
+	})
+	return err
+}
+
+func validateRef(ref Ref) error {
+	if ref.Bucket == "" || ref.Key == "" {
+		return fmt.Errorf("%w: bucket=%q key=%q", ErrInvalidRef, ref.Bucket, ref.Key)
+	}
+	return nil
+}

--- a/pkg/services/sqs_large_payload/s3_store.go
+++ b/pkg/services/sqs_large_payload/s3_store.go
@@ -45,12 +45,12 @@ func (s S3Store) Put(ctx context.Context, ref Ref, payload []byte) error {
 }
 
 // Get retrieves the payload bytes from the specified bucket + key.
-func (s S3Store) Get(ctx context.Context, ref Ref) ([]byte, error) {
+func (s S3Store) Get(ctx context.Context, ref Ref) (payload []byte, err error) {
 	if s.Client == nil {
 		return nil, ErrNilS3Client
 	}
-	if err := validateRef(ref); err != nil {
-		return nil, err
+	if validateErr := validateRef(ref); validateErr != nil {
+		return nil, validateErr
 	}
 
 	out, err := s.Client.GetObject(ctx, &s3.GetObjectInput{
@@ -60,9 +60,13 @@ func (s S3Store) Get(ctx context.Context, ref Ref) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = out.Body.Close() }()
+	defer func() {
+		if closeErr := out.Body.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
 
-	payload, err := io.ReadAll(out.Body)
+	payload, err = io.ReadAll(out.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/sqs_large_payload/s3_store_test.go
+++ b/pkg/services/sqs_large_payload/s3_store_test.go
@@ -1,0 +1,109 @@
+package sqslargepayload
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func TestS3Store_NilClient(t *testing.T) {
+	store := S3Store{}
+	ref := Ref{Bucket: "b", Key: "k"}
+
+	if err := store.Put(context.Background(), ref, []byte("x")); !errors.Is(err, ErrNilS3Client) {
+		t.Fatalf("expected ErrNilS3Client, got %v", err)
+	}
+	if _, err := store.Get(context.Background(), ref); !errors.Is(err, ErrNilS3Client) {
+		t.Fatalf("expected ErrNilS3Client, got %v", err)
+	}
+	if err := store.Delete(context.Background(), ref); !errors.Is(err, ErrNilS3Client) {
+		t.Fatalf("expected ErrNilS3Client, got %v", err)
+	}
+}
+
+func TestS3Store_InvalidRef(t *testing.T) {
+	client := newFakeS3()
+	store := S3Store{Client: client}
+
+	if err := store.Put(context.Background(), Ref{}, []byte("x")); !errors.Is(err, ErrInvalidRef) {
+		t.Fatalf("expected ErrInvalidRef, got %v", err)
+	}
+	if _, err := store.Get(context.Background(), Ref{}); !errors.Is(err, ErrInvalidRef) {
+		t.Fatalf("expected ErrInvalidRef, got %v", err)
+	}
+	if err := store.Delete(context.Background(), Ref{}); !errors.Is(err, ErrInvalidRef) {
+		t.Fatalf("expected ErrInvalidRef, got %v", err)
+	}
+}
+
+func TestS3Store_PutGetDelete(t *testing.T) {
+	ctx := context.Background()
+	client := newFakeS3()
+	store := S3Store{Client: client}
+	ref := Ref{Bucket: "bucket", Key: "key"}
+	payload := []byte("payload")
+
+	if err := store.Put(ctx, ref, payload); err != nil {
+		t.Fatalf("unexpected put error: %v", err)
+	}
+
+	got, err := store.Get(ctx, ref)
+	if err != nil {
+		t.Fatalf("unexpected get error: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("expected payload %q got %q", payload, got)
+	}
+
+	if err := store.Delete(ctx, ref); err != nil {
+		t.Fatalf("unexpected delete error: %v", err)
+	}
+	if _, err := store.Get(ctx, ref); err == nil {
+		t.Fatalf("expected get to fail after delete")
+	}
+}
+
+type fakeS3 struct {
+	objects map[Ref][]byte
+}
+
+func newFakeS3() *fakeS3 {
+	return &fakeS3{objects: make(map[Ref][]byte)}
+}
+
+func (f *fakeS3) PutObject(_ context.Context, params *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if params == nil || params.Bucket == nil || params.Key == nil || params.Body == nil {
+		return nil, errors.New("invalid input")
+	}
+	body, err := io.ReadAll(params.Body)
+	if err != nil {
+		return nil, err
+	}
+	f.objects[Ref{Bucket: *params.Bucket, Key: *params.Key}] = append([]byte(nil), body...)
+	return &s3.PutObjectOutput{}, nil
+}
+
+func (f *fakeS3) GetObject(_ context.Context, params *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if params == nil || params.Bucket == nil || params.Key == nil {
+		return nil, errors.New("invalid input")
+	}
+	payload, ok := f.objects[Ref{Bucket: *params.Bucket, Key: *params.Key}]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return &s3.GetObjectOutput{
+		Body: io.NopCloser(bytes.NewReader(payload)),
+	}, nil
+}
+
+func (f *fakeS3) DeleteObject(_ context.Context, params *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	if params == nil || params.Bucket == nil || params.Key == nil {
+		return nil, errors.New("invalid input")
+	}
+	delete(f.objects, Ref{Bucket: *params.Bucket, Key: *params.Key})
+	return &s3.DeleteObjectOutput{}, nil
+}


### PR DESCRIPTION
This pull request introduces first-class support for handling large SQS message payloads in Lift by offloading oversized message bodies to S3 and using pointer envelopes in SQS. It includes comprehensive documentation, a detailed engineering roadmap, and a new working example. These changes make it easier for users to opt-in to the extended payload pattern, implement producers and consumers in Go, and understand the operational and security considerations.

**Documentation and Roadmap:**

- Added a new documentation page (`cdk-sqs-large-payloads.md`) explaining the SQS large payload pattern, including how to enable it in CDK, Go producer/consumer code samples, configuration options, and operational notes.
- Added a detailed engineering roadmap (`planning/sqs-large-payload-s3.md`) outlining the design, goals, milestones, risks, and open questions for supporting SQS large payloads via S3 in Lift.

**CDK and Example References:**

- Updated documentation indexes (`README.md`, `cdk.md`) to reference the new SQS large payloads documentation, making it discoverable for users. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R37) [[2]](diffhunk://#diff-48349cc6baac638d2d316ceca034b33492ff9e4b5a0891a1be5a4fbe0726ad0aR15)
- Added a new example (`examples/sqs-large-payload/`) demonstrating the pattern, with a README describing how to run and what to expect. [[1]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9R19) [[2]](diffhunk://#diff-1686209a209e91585416a00f9f10da505849c78d2b2da10d7651138b70dc93e1R1-R26)