### PR TITLE
fix(ci): publish release assets via github.token

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
@@ -35,10 +38,21 @@ jobs:
           fi
 
       - name: Release Please (Prerelease)
+        id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           target-branch: premain
           config-file: release-please-config.premain.json
           manifest-file: .release-please-manifest.premain.json
           release-as: ${{ steps.release_as.outputs.release_as }}
+
+  publish-assets:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+      prerelease: true
+    permissions:
+      contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
@@ -35,10 +38,21 @@ jobs:
           fi
 
       - name: Release Please (Stable)
+        id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           release-as: ${{ steps.release_as.outputs.release_as }}
+
+  publish-assets:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+      prerelease: false
+    permissions:
+      contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,118 +1,109 @@
-name: Release
+name: Publish Release Assets
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      tag_name:
+        description: Tag name (e.g. v1.1.0 or v1.1.0-rc.1)
+        required: true
+        type: string
+      prerelease:
+        description: Whether the release is a prerelease
+        required: true
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Tag name (e.g. v1.1.0 or v1.1.0-rc.1)
+        required: true
+        type: string
+      prerelease:
+        description: Whether the release is a prerelease
+        required: true
+        type: boolean
 
 permissions:
   contents: write
 
 jobs:
-  release:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - name: Checkout
+      - name: Checkout (tag)
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag_name }}
           persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
           check-latest: true
           cache: true
-
-      - name: Get version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Run tests
         run: go test -short ./...
 
       - name: Build binaries
+        env:
+          VERSION: ${{ inputs.tag_name }}
         run: |
-          VERSION=${{ steps.version.outputs.VERSION }}
-          
-          # Create dist directory
+          set -euo pipefail
           mkdir -p dist
-          
-          # Build for Linux amd64
+
           echo "Building linux/amd64..."
-          GOOS=linux GOARCH=amd64 go build \
-            -ldflags="-s -w -X main.Version=${VERSION}" \
-            -o dist/lift-linux-amd64 \
-            ./cmd/lift
-          
-          # Build for Linux arm64
+          GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X main.Version=${VERSION}" -o dist/lift-linux-amd64 ./cmd/lift
+
           echo "Building linux/arm64..."
-          GOOS=linux GOARCH=arm64 go build \
-            -ldflags="-s -w -X main.Version=${VERSION}" \
-            -o dist/lift-linux-arm64 \
-            ./cmd/lift
-          
-          # Build for macOS amd64
+          GOOS=linux GOARCH=arm64 go build -ldflags="-s -w -X main.Version=${VERSION}" -o dist/lift-linux-arm64 ./cmd/lift
+
           echo "Building darwin/amd64..."
-          GOOS=darwin GOARCH=amd64 go build \
-            -ldflags="-s -w -X main.Version=${VERSION}" \
-            -o dist/lift-darwin-amd64 \
-            ./cmd/lift
-          
-          # Build for macOS arm64 (Apple Silicon)
+          GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X main.Version=${VERSION}" -o dist/lift-darwin-amd64 ./cmd/lift
+
           echo "Building darwin/arm64..."
-          GOOS=darwin GOARCH=arm64 go build \
-            -ldflags="-s -w -X main.Version=${VERSION}" \
-            -o dist/lift-darwin-arm64 \
-            ./cmd/lift
-          
-          # Build for Windows amd64
+          GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w -X main.Version=${VERSION}" -o dist/lift-darwin-arm64 ./cmd/lift
+
           echo "Building windows/amd64..."
-          GOOS=windows GOARCH=amd64 go build \
-            -ldflags="-s -w -X main.Version=${VERSION}" \
-            -o dist/lift-windows-amd64.exe \
-            ./cmd/lift
-          
-          # Build for Windows arm64
+          GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X main.Version=${VERSION}" -o dist/lift-windows-amd64.exe ./cmd/lift
+
           echo "Building windows/arm64..."
-          GOOS=windows GOARCH=arm64 go build \
-            -ldflags="-s -w -X main.Version=${VERSION}" \
-            -o dist/lift-windows-arm64.exe \
-            ./cmd/lift
+          GOOS=windows GOARCH=arm64 go build -ldflags="-s -w -X main.Version=${VERSION}" -o dist/lift-windows-arm64.exe ./cmd/lift
 
       - name: Create checksums
         run: |
+          set -euo pipefail
           cd dist
           sha256sum lift-* > checksums.txt
           cat checksums.txt
 
       - name: Create archives
+        env:
+          VERSION: ${{ inputs.tag_name }}
         run: |
+          set -euo pipefail
           cd dist
-          VERSION=${{ steps.version.outputs.VERSION }}
-          
-          # Create tarballs for Unix systems
+
           tar -czvf lift-${VERSION}-linux-amd64.tar.gz lift-linux-amd64
           tar -czvf lift-${VERSION}-linux-arm64.tar.gz lift-linux-arm64
           tar -czvf lift-${VERSION}-darwin-amd64.tar.gz lift-darwin-amd64
           tar -czvf lift-${VERSION}-darwin-arm64.tar.gz lift-darwin-arm64
-          
-          # Create zip for Windows
+
           zip lift-${VERSION}-windows-amd64.zip lift-windows-amd64.exe
           zip lift-${VERSION}-windows-arm64.zip lift-windows-arm64.exe
 
-      - name: Create Release
+      - name: Upload release assets
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
         with:
+          tag_name: ${{ inputs.tag_name }}
           draft: false
-          prerelease: ${{ contains(steps.version.outputs.VERSION, '-') }}
-          generate_release_notes: true
+          prerelease: ${{ inputs.prerelease }}
+          generate_release_notes: false
+          fail_on_unmatched_files: true
           files: |
             dist/lift-*.tar.gz
             dist/lift-*.zip
             dist/checksums.txt
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/hgm-infra/evidence/hgm-rubric-report.json
+++ b/hgm-infra/evidence/hgm-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://hgm.pai.dev/schemas/hgm-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-01-14T14:24:33Z",
+  "timestamp": "2026-01-14T16:29:26Z",
   "pack": {
     "version": "4ae6c743d023",
     "digest": "83338d5db82b9af9247475a62d08623a3e930b6b6e2466d68b254d6842c1f2c2"

--- a/hgm-infra/planning/lift-10of10-roadmap.md
+++ b/hgm-infra/planning/lift-10of10-roadmap.md
@@ -1,8 +1,8 @@
-# Lift: 10/10 Roadmap (Rubric v0.6)
+# Lift: 10/10 Roadmap (Rubric v0.7)
 
 This roadmap maps milestones directly to rubric IDs with measurable acceptance criteria and verification commands.
 
-## Current scorecard (Rubric v0.6)
+## Current scorecard (Rubric v0.7)
 
 Scoring note: a check is only treated as “passing” if it is both green and enforced by a trustworthy verifier
 (pinned tooling, schema-valid configs, and no “green by dilution” shortcuts). Completeness failures invalidate “green by
@@ -143,4 +143,5 @@ Tracking document: `hgm-infra/planning/lift-coverage-roadmap.md`
 - CI runs the full rubric surface via a single command (`make rubric`) on PRs/pushes to `premain` and `main`.
 - Evidence artifacts (`hgm-infra/evidence/**`) are uploaded by CI.
 - Release automation is defined for `premain` (prereleases) and `main` (stable) via pinned release-please workflows.
+- Release asset publishing is driven from the release-please workflows (no tag-push chaining; no manual tokens).
 - CodeQL workflow exists and runs on both `premain` and `main`.

--- a/hgm-infra/planning/lift-10of10-rubric.md
+++ b/hgm-infra/planning/lift-10of10-rubric.md
@@ -4,7 +4,7 @@ This rubric defines what “10/10” means and how category grades are computed.
 “green by dilution” by making scoring versioned, measurable, and repeatable.
 
 ## Versioning (no moving goalposts)
-- **Rubric version:** `v0.6` (2026-01-14)
+- **Rubric version:** `v0.7` (2026-01-14)
 - **Comparability rule:** grades are comparable only within the same version.
 - **Change rule:** bump the version + changelog entry for any rubric change (what changed + why).
 
@@ -15,6 +15,7 @@ This rubric defines what “10/10” means and how category grades are computed.
 - `v0.4`: Define verifiers for MAI-1..MAI-3 (budgets, roadmap, duplicate code gate).
 - `v0.5`: Define verifier for SEC-2 (dependency vulnerability scan) via pinned govulncheck.
 - `v0.6`: Require CI rubric enforcement + branch/release automation (aligned with DynamORM release CI).
+- `v0.7`: Require cloud-token release asset publishing (no manual tokens; no tag-push chaining).
 
 ## Scoring (deterministic)
 - Each category is scored 0–10.
@@ -64,7 +65,7 @@ Enforcement rule (anti-drift):
 | COM-5 | 1 | Security scan config not diluted (no excluded high-signal rules) | verifier COM-5 (fails if gosec excludes high-signal IDs like G101) |
 | COM-6 | 1 | Logging/operational standards enforced (if applicable) | verifier COM-6 (runs `go test -count=1 -run '^TestOps_' ./pkg/observability/zap ./pkg/middleware`) |
 | COM-7 | 2 | CI enforces the full rubric surface | verifier COM-7 (checks `quality-gates` workflow runs `make rubric` + uploads evidence) |
-| COM-8 | 2 | Branch + release automation enforced (main release, premain prerelease) | verifier COM-8 (checks release-please workflows + policy doc + CodeQL/quality gates triggers) |
+| COM-8 | 2 | Branch + release automation enforced (main release, premain prerelease) | verifier COM-8 (checks release-please workflows + reusable asset publishing + policy doc + CodeQL/quality gates triggers) |
 
 **10/10 definition:** COM-1 through COM-8 pass.
 

--- a/hgm-infra/planning/lift-branch-release-policy.md
+++ b/hgm-infra/planning/lift-branch-release-policy.md
@@ -35,8 +35,12 @@ Recommended approach: **release-please** (merge-driven versioning + changelog up
 - release workflow producing stable `vX.Y.Z` tags and updating `CHANGELOG.md`.
 
 Publishing approach:
-- `release-please` creates the tag.
-- `.github/workflows/release.yml` builds and publishes Lift binaries on tag pushes.
+- `release-please` creates the tag + GitHub release (notes) using the built-in `GITHUB_TOKEN`.
+- `prerelease.yml` / `release-please.yml` call `.github/workflows/release.yml` (via `workflow_call`) to build and upload
+  Lift binaries to the GitHub Release (no tag-push chaining, no manual tokens).
+
+Commit discipline (required):
+- Use Conventional Commits (`fix:`, `feat:`, etc.) so release-please can detect user-facing changes and cut releases.
 
 ## Required workflow artifacts (Rubric COM-8)
 

--- a/hgm-infra/planning/lift-coverage-roadmap.md
+++ b/hgm-infra/planning/lift-coverage-roadmap.md
@@ -1,4 +1,4 @@
-# Lift: Coverage Roadmap (to 90%) (Rubric v0.6)
+# Lift: Coverage Roadmap (to 90%) (Rubric v0.7)
 
 Goal: raise and maintain meaningful coverage to **≥ 90%** as measured by the rubric verifier coverage command, without
 reducing the measurement surface.

--- a/hgm-infra/planning/lift-evidence-plan.md
+++ b/hgm-infra/planning/lift-evidence-plan.md
@@ -1,4 +1,4 @@
-# Lift Evidence Plan (Rubric v0.6)
+# Lift Evidence Plan (Rubric v0.7)
 
 Defines where evidence for rubric items is produced and how to regenerate it. Evidence should be reproducible from a
 commit SHA (no hand-assembled screenshots unless unavoidable).

--- a/hgm-infra/planning/lift-lint-green-roadmap.md
+++ b/hgm-infra/planning/lift-lint-green-roadmap.md
@@ -1,4 +1,4 @@
-# Lift: Lint Green Roadmap (Rubric v0.6)
+# Lift: Lint Green Roadmap (Rubric v0.7)
 
 Goal: keep/get to a green `make lint` pass using the repo’s strict lint configuration, **without** weakening thresholds or
 adding blanket exclusions.

--- a/hgm-infra/planning/lift-maintainability-roadmap.md
+++ b/hgm-infra/planning/lift-maintainability-roadmap.md
@@ -1,4 +1,4 @@
-# Lift: Maintainability Roadmap (Rubric v0.6)
+# Lift: Maintainability Roadmap (Rubric v0.7)
 
 Goal: prevent AI/agent-driven drift that makes security fixes risky by enforcing lightweight budgets and keeping a clear,
 reviewable plan for paydown.

--- a/hgm-infra/verifiers/hgm-verify-rubric.sh
+++ b/hgm-infra/verifiers/hgm-verify-rubric.sh
@@ -485,6 +485,7 @@ hgm_check_branch_release_supply_chain() {
     ".release-please-manifest.premain.json"
     ".github/workflows/prerelease.yml"
     ".github/workflows/release-please.yml"
+    ".github/workflows/release.yml"
     ".github/workflows/quality-gates.yml"
     ".github/workflows/codeql.yml"
   )
@@ -513,6 +514,10 @@ hgm_check_branch_release_supply_chain() {
   fi
 
   if [[ -f ".github/workflows/prerelease.yml" ]]; then
+    if grep -q 'RELEASE_PLEASE_TOKEN' ".github/workflows/prerelease.yml"; then
+      echo "branch-release: prerelease workflow must not require a manual token (RELEASE_PLEASE_TOKEN)"
+      failures=$((failures + 1))
+    fi
     grep -Eq 'branches:.*premain' ".github/workflows/prerelease.yml" || {
       echo "branch-release: prerelease workflow must target premain"
       failures=$((failures + 1))
@@ -533,9 +538,17 @@ hgm_check_branch_release_supply_chain() {
       echo "branch-release: prerelease workflow must reference .release-please-manifest.premain.json"
       failures=$((failures + 1))
     }
+    grep -q 'uses: ./.github/workflows/release.yml' ".github/workflows/prerelease.yml" || {
+      echo "branch-release: prerelease workflow must publish assets via reusable .github/workflows/release.yml"
+      failures=$((failures + 1))
+    }
   fi
 
   if [[ -f ".github/workflows/release-please.yml" ]]; then
+    if grep -q 'RELEASE_PLEASE_TOKEN' ".github/workflows/release-please.yml"; then
+      echo "branch-release: release workflow must not require a manual token (RELEASE_PLEASE_TOKEN)"
+      failures=$((failures + 1))
+    fi
     grep -Eq 'branches:.*main' ".github/workflows/release-please.yml" || {
       echo "branch-release: release workflow must target main"
       failures=$((failures + 1))
@@ -554,6 +567,29 @@ hgm_check_branch_release_supply_chain() {
     }
     grep -Eq 'manifest-file:[[:space:]]*\.release-please-manifest\.json' ".github/workflows/release-please.yml" || {
       echo "branch-release: release workflow must reference .release-please-manifest.json"
+      failures=$((failures + 1))
+    }
+    grep -q 'uses: ./.github/workflows/release.yml' ".github/workflows/release-please.yml" || {
+      echo "branch-release: release workflow must publish assets via reusable .github/workflows/release.yml"
+      failures=$((failures + 1))
+    }
+  fi
+
+  if [[ -f ".github/workflows/release.yml" ]]; then
+    grep -q 'workflow_call:' ".github/workflows/release.yml" || {
+      echo "branch-release: release.yml must support workflow_call (for cloud-token releases)"
+      failures=$((failures + 1))
+    }
+    grep -q 'workflow_dispatch:' ".github/workflows/release.yml" || {
+      echo "branch-release: release.yml must support workflow_dispatch (for manual reruns)"
+      failures=$((failures + 1))
+    }
+    if grep -Eq '^[[:space:]]+push:' ".github/workflows/release.yml"; then
+      echo "branch-release: release.yml must not rely on tag-push chaining"
+      failures=$((failures + 1))
+    fi
+    grep -q 'GITHUB_TOKEN: ${{ github.token }}' ".github/workflows/release.yml" || {
+      echo "branch-release: release.yml must use github.token (cloud token) for uploads"
       failures=$((failures + 1))
     }
   fi


### PR DESCRIPTION
- Make release asset publishing work with cloud-derived GitHub tokens (no manual token, no tag-push chaining)\n- Bump Lift 10/10 rubric + planning docs to v0.7 and refresh evidence