### PR TITLE
fix(ci): support immutable GitHub releases

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -23,20 +23,6 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Force initial prerelease line (v1.1.0)
-        id: release_as
-        shell: bash
-        run: |
-          set -euo pipefail
-          want="1.1.0"
-          current="$(node -p "require('./.release-please-manifest.premain.json')['.']")"
-          echo "manifest_version=${current}"
-          if [[ "${current}" == "${want}"* ]]; then
-            echo "release_as=" >> "${GITHUB_OUTPUT}"
-          else
-            echo "release_as=${want}" >> "${GITHUB_OUTPUT}"
-          fi
-
       - name: Release Please (Prerelease)
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
@@ -45,7 +31,6 @@ jobs:
           target-branch: premain
           config-file: release-please-config.premain.json
           manifest-file: .release-please-manifest.premain.json
-          release-as: ${{ steps.release_as.outputs.release_as }}
 
   publish-assets:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,20 +23,6 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Force initial stable release line (v1.1.0)
-        id: release_as
-        shell: bash
-        run: |
-          set -euo pipefail
-          want="1.1.0"
-          current="$(node -p "require('./.release-please-manifest.json')['.']")"
-          echo "manifest_version=${current}"
-          if [[ "${current}" == "${want}" ]]; then
-            echo "release_as=" >> "${GITHUB_OUTPUT}"
-          else
-            echo "release_as=${want}" >> "${GITHUB_OUTPUT}"
-          fi
-
       - name: Release Please (Stable)
         id: release
         uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
@@ -45,7 +31,6 @@ jobs:
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          release-as: ${{ steps.release_as.outputs.release_as }}
 
   publish-assets:
     needs: release-please

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,11 @@ jobs:
           zip lift-${VERSION}-windows-arm64.zip lift-windows-arm64.exe
 
       - name: Upload release assets
+        id: upload
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
         with:
           tag_name: ${{ inputs.tag_name }}
-          draft: false
+          draft: true
           prerelease: ${{ inputs.prerelease }}
           generate_release_notes: false
           fail_on_unmatched_files: true
@@ -107,3 +108,16 @@ jobs:
             dist/checksums.txt
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Publish release (make immutable)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.upload.outputs.id }}
+        run: |
+          set -euo pipefail
+          curl -sSf \
+            -X PATCH \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
+            -d '{"draft":false}'

--- a/hgm-infra/evidence/hgm-rubric-report.json
+++ b/hgm-infra/evidence/hgm-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://hgm.pai.dev/schemas/hgm-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-01-14T16:29:26Z",
+  "timestamp": "2026-01-14T17:00:12Z",
   "pack": {
     "version": "4ae6c743d023",
     "digest": "83338d5db82b9af9247475a62d08623a3e930b6b6e2466d68b254d6842c1f2c2"

--- a/hgm-infra/evidence/hgm-rubric-report.json
+++ b/hgm-infra/evidence/hgm-rubric-report.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://hgm.pai.dev/schemas/hgm-rubric-report.schema.json",
   "schemaVersion": 1,
-  "timestamp": "2026-01-14T17:00:12Z",
+  "timestamp": "2026-01-14T17:07:57Z",
   "pack": {
     "version": "4ae6c743d023",
     "digest": "83338d5db82b9af9247475a62d08623a3e930b6b6e2466d68b254d6842c1f2c2"

--- a/hgm-infra/planning/lift-10of10-roadmap.md
+++ b/hgm-infra/planning/lift-10of10-roadmap.md
@@ -1,8 +1,8 @@
-# Lift: 10/10 Roadmap (Rubric v0.7)
+# Lift: 10/10 Roadmap (Rubric v0.8)
 
 This roadmap maps milestones directly to rubric IDs with measurable acceptance criteria and verification commands.
 
-## Current scorecard (Rubric v0.7)
+## Current scorecard (Rubric v0.8)
 
 Scoring note: a check is only treated as “passing” if it is both green and enforced by a trustworthy verifier
 (pinned tooling, schema-valid configs, and no “green by dilution” shortcuts). Completeness failures invalidate “green by
@@ -144,4 +144,5 @@ Tracking document: `hgm-infra/planning/lift-coverage-roadmap.md`
 - Evidence artifacts (`hgm-infra/evidence/**`) are uploaded by CI.
 - Release automation is defined for `premain` (prereleases) and `main` (stable) via pinned release-please workflows.
 - Release asset publishing is driven from the release-please workflows (no tag-push chaining; no manual tokens).
+- Release automation remains compatible with "immutable releases" (draft, upload assets, then publish).
 - CodeQL workflow exists and runs on both `premain` and `main`.

--- a/hgm-infra/planning/lift-10of10-rubric.md
+++ b/hgm-infra/planning/lift-10of10-rubric.md
@@ -4,7 +4,7 @@ This rubric defines what “10/10” means and how category grades are computed.
 “green by dilution” by making scoring versioned, measurable, and repeatable.
 
 ## Versioning (no moving goalposts)
-- **Rubric version:** `v0.7` (2026-01-14)
+- **Rubric version:** `v0.8` (2026-01-14)
 - **Comparability rule:** grades are comparable only within the same version.
 - **Change rule:** bump the version + changelog entry for any rubric change (what changed + why).
 
@@ -16,6 +16,7 @@ This rubric defines what “10/10” means and how category grades are computed.
 - `v0.5`: Define verifier for SEC-2 (dependency vulnerability scan) via pinned govulncheck.
 - `v0.6`: Require CI rubric enforcement + branch/release automation (aligned with DynamORM release CI).
 - `v0.7`: Require cloud-token release asset publishing (no manual tokens; no tag-push chaining).
+- `v0.8`: Require immutable-release-compatible automation (draft release, upload assets, then publish).
 
 ## Scoring (deterministic)
 - Each category is scored 0–10.
@@ -65,7 +66,7 @@ Enforcement rule (anti-drift):
 | COM-5 | 1 | Security scan config not diluted (no excluded high-signal rules) | verifier COM-5 (fails if gosec excludes high-signal IDs like G101) |
 | COM-6 | 1 | Logging/operational standards enforced (if applicable) | verifier COM-6 (runs `go test -count=1 -run '^TestOps_' ./pkg/observability/zap ./pkg/middleware`) |
 | COM-7 | 2 | CI enforces the full rubric surface | verifier COM-7 (checks `quality-gates` workflow runs `make rubric` + uploads evidence) |
-| COM-8 | 2 | Branch + release automation enforced (main release, premain prerelease) | verifier COM-8 (checks release-please workflows + reusable asset publishing + policy doc + CodeQL/quality gates triggers) |
+| COM-8 | 2 | Branch + release automation enforced (main release, premain prerelease) | verifier COM-8 (checks release-please workflows + draft/publish asset publishing + policy doc + CodeQL/quality gates triggers) |
 
 **10/10 definition:** COM-1 through COM-8 pass.
 

--- a/hgm-infra/planning/lift-branch-release-policy.md
+++ b/hgm-infra/planning/lift-branch-release-policy.md
@@ -29,6 +29,9 @@ This repo should publish:
 - **Prereleases** on merges to `premain`.
 - **Releases** on merges to `main`.
 
+Versioning note:
+- The post-HGM baseline release line starts at `v1.1.0` (prereleases: `v1.1.0-rc.N`).
+
 Recommended approach: **release-please** (merge-driven versioning + changelog updates) with:
 
 - prerelease workflow producing tags like `vX.Y.Z-rc.N`, and

--- a/hgm-infra/planning/lift-branch-release-policy.md
+++ b/hgm-infra/planning/lift-branch-release-policy.md
@@ -38,6 +38,8 @@ Publishing approach:
 - `release-please` creates the tag + GitHub release (notes) using the built-in `GITHUB_TOKEN`.
 - `prerelease.yml` / `release-please.yml` call `.github/workflows/release.yml` (via `workflow_call`) to build and upload
   Lift binaries to the GitHub Release (no tag-push chaining, no manual tokens).
+- Repos with "immutable releases" enabled must publish assets while the GitHub Release is still a **draft**, then publish
+  the release after assets upload completes.
 
 Commit discipline (required):
 - Use Conventional Commits (`fix:`, `feat:`, etc.) so release-please can detect user-facing changes and cut releases.

--- a/hgm-infra/planning/lift-coverage-roadmap.md
+++ b/hgm-infra/planning/lift-coverage-roadmap.md
@@ -1,4 +1,4 @@
-# Lift: Coverage Roadmap (to 90%) (Rubric v0.7)
+# Lift: Coverage Roadmap (to 90%) (Rubric v0.8)
 
 Goal: raise and maintain meaningful coverage to **≥ 90%** as measured by the rubric verifier coverage command, without
 reducing the measurement surface.

--- a/hgm-infra/planning/lift-evidence-plan.md
+++ b/hgm-infra/planning/lift-evidence-plan.md
@@ -1,4 +1,4 @@
-# Lift Evidence Plan (Rubric v0.7)
+# Lift Evidence Plan (Rubric v0.8)
 
 Defines where evidence for rubric items is produced and how to regenerate it. Evidence should be reproducible from a
 commit SHA (no hand-assembled screenshots unless unavoidable).

--- a/hgm-infra/planning/lift-lint-green-roadmap.md
+++ b/hgm-infra/planning/lift-lint-green-roadmap.md
@@ -1,4 +1,4 @@
-# Lift: Lint Green Roadmap (Rubric v0.7)
+# Lift: Lint Green Roadmap (Rubric v0.8)
 
 Goal: keep/get to a green `make lint` pass using the repo’s strict lint configuration, **without** weakening thresholds or
 adding blanket exclusions.

--- a/hgm-infra/planning/lift-maintainability-roadmap.md
+++ b/hgm-infra/planning/lift-maintainability-roadmap.md
@@ -1,4 +1,4 @@
-# Lift: Maintainability Roadmap (Rubric v0.7)
+# Lift: Maintainability Roadmap (Rubric v0.8)
 
 Goal: prevent AI/agent-driven drift that makes security fixes risky by enforcing lightweight budgets and keeping a clear,
 reviewable plan for paydown.

--- a/hgm-infra/verifiers/hgm-verify-rubric.sh
+++ b/hgm-infra/verifiers/hgm-verify-rubric.sh
@@ -592,7 +592,25 @@ hgm_check_branch_release_supply_chain() {
       echo "branch-release: release.yml must use github.token (cloud token) for uploads"
       failures=$((failures + 1))
     }
+
+    grep -Eq 'draft:[[:space:]]*true' ".github/workflows/release.yml" || {
+      echo "branch-release: release.yml must upload assets while release is a draft"
+      failures=$((failures + 1))
+    }
+    grep -Fq '{"draft":false}' ".github/workflows/release.yml" || {
+      echo "branch-release: release.yml must publish the release after assets upload"
+      failures=$((failures + 1))
+    }
   fi
+
+  for cfg in "release-please-config.premain.json" "release-please-config.json"; do
+    if [[ -f "${cfg}" ]]; then
+      grep -q '"draft": true' "${cfg}" || {
+        echo "branch-release: ${cfg}: must create releases as drafts (immutable releases compatible)"
+        failures=$((failures + 1))
+      }
+    fi
+  done
 
   for wf in ".github/workflows/quality-gates.yml" ".github/workflows/codeql.yml"; do
     if [[ ! -f "${wf}" ]]; then

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "release-type": "go",
   "include-v-in-tag": true,
+  "draft": true,
   "packages": {
     ".": {}
   }

--- a/release-please-config.premain.json
+++ b/release-please-config.premain.json
@@ -1,6 +1,7 @@
 {
   "release-type": "go",
   "include-v-in-tag": true,
+  "draft": true,
   "versioning": "prerelease",
   "prerelease-type": "rc",
   "prerelease": true,


### PR DESCRIPTION
- Fix prerelease/stable asset publishing when GitHub repo has immutable releases enabled\n- Release-please creates draft releases; assets upload happens while draft; workflow then publishes the release\n- Bump Lift 10/10 rubric + planning to v0.8 and refresh evidence